### PR TITLE
Allow ff-button to be centered in a container

### DIFF
--- a/dist/forge-ui-components.css
+++ b/dist/forge-ui-components.css
@@ -39,7 +39,7 @@ code {
 .ff-btn {
   padding: 6px 18px;
   border-radius: 6px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   font-size: 0.85rem;
   line-height: 20px;

--- a/dist/forge-ui-components.js
+++ b/dist/forge-ui-components.js
@@ -5,6 +5,10 @@ var vue = require('vue');
 var script$1 = {
     name: 'ff-button',
     props: {
+        type: {
+            default: 'button', // "button" or "submit"
+            type: String
+        },
         kind: {
             default: 'primary',
             type: String // "primary", "secondary", "tertiary"
@@ -56,6 +60,7 @@ const _hoisted_3 = {
 function render$1(_ctx, _cache, $props, $setup, $data, $options) {
   return (vue.openBlock(), vue.createElementBlock("button", {
     class: vue.normalizeClass(["ff-btn", 'ff-btn--' + $props.kind + ($options.hasIcon ? ' ff-btn-icon' : '') + ($props.size === 'small' ? ' ff-btn-small' : '') + ($props.size === 'full-width' ? ' ff-btn-fwidth' : '')]),
+    type: "button",
     onClick: _cache[0] || (_cache[0] = $event => ($options.go()))
   }, [
     ($options.hasIconLeft)

--- a/dist/forge-ui-components.mjs
+++ b/dist/forge-ui-components.mjs
@@ -3,6 +3,10 @@ import { openBlock, createElementBlock, normalizeClass, renderSlot, createCommen
 var script$1 = {
     name: 'ff-button',
     props: {
+        type: {
+            default: 'button', // "button" or "submit"
+            type: String
+        },
         kind: {
             default: 'primary',
             type: String // "primary", "secondary", "tertiary"
@@ -54,6 +58,7 @@ const _hoisted_3 = {
 function render$1(_ctx, _cache, $props, $setup, $data, $options) {
   return (openBlock(), createElementBlock("button", {
     class: normalizeClass(["ff-btn", 'ff-btn--' + $props.kind + ($options.hasIcon ? ' ff-btn-icon' : '') + ($props.size === 'small' ? ' ff-btn-small' : '') + ($props.size === 'full-width' ? ' ff-btn-fwidth' : '')]),
+    type: "button",
     onClick: _cache[0] || (_cache[0] = $event => ($options.go()))
   }, [
     ($options.hasIconLeft)

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -5,7 +5,7 @@
 .ff-btn {
   padding: $ff-unit-sm $ff-unit-lg;
   border-radius: $ff-unit-sm;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   font-size: $ff-funit-sm;
   line-height: 20px;


### PR DESCRIPTION
Fixes #4

Changes the `display` property of `ff-btn` to `inline-flex`

I've also included the updated `dist` files - not sure if we should do that for each PR, or just when we publish a release. But figured having the dist files up to date makes it easier to run from src.