### PR TITLE
TextInput: create 'type' property

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -88,6 +88,10 @@
                         <ff-text-input type="password" placeholder="Password goes here..."/>
                         <code>{{ groups[1].components[0].examples[1].code }}</code>
                     </div>
+                    <div class="example">
+                        <ff-text-input type="email"/>
+                        <code>{{ groups[1].components[0].examples[2].code }}</code>
+                    </div>
                 </div>
             </div>
         </div>
@@ -178,6 +182,8 @@ export default {
                         code: '<ff-text-input v-model="myVar" placeholder="Insert something here..." />'
                     }, {
                         code: '<ff-text-input :type"password" v-model="myPassword" placeholder="Password goes here..." />'
+                    }, {
+                        code: '<ff-text-input :type"email" v-model="myEmail" />'
                     }],
                     props: [{
                         key: 'disabled',
@@ -190,7 +196,7 @@ export default {
                     }, {
                         key: 'type',
                         default: 'text',
-                        description: 'Text or password, password hides the content of the text input'
+                        description: 'text, email, or password. password hides the content of the text input'
                     }]
                 }]
             }]

--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -85,7 +85,7 @@
                         <code>{{ groups[1].components[0].examples[0].code }}</code>
                     </div>
                     <div class="example">
-                        <ff-text-input :password="true" placeholder="Password goes here..."/>
+                        <ff-text-input type="password" placeholder="Password goes here..."/>
                         <code>{{ groups[1].components[0].examples[1].code }}</code>
                     </div>
                 </div>
@@ -177,7 +177,7 @@ export default {
                     examples: [{
                         code: '<ff-text-input v-model="myVar" placeholder="Insert something here..." />'
                     }, {
-                        code: '<ff-text-input :password"true" v-model="myPassword" placeholder="Password goes here..." />'
+                        code: '<ff-text-input :type"password" v-model="myPassword" placeholder="Password goes here..." />'
                     }],
                     props: [{
                         key: 'disabled',
@@ -188,9 +188,9 @@ export default {
                         default: 'null',
                         description: 'Informative text to assist the user with the information required in this input field.'
                     }, {
-                        key: 'password',
-                        default: 'false',
-                        description: 'Hide the content of this text input as a password field.'
+                        key: 'type',
+                        default: 'text',
+                        description: 'Text or password, password hides the content of the text input'
                     }]
                 }]
             }]

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -28,7 +28,7 @@ export default {
             type: String // "small", "normal"
         },
         type: {
-            default: 'text', // One of: 'text' or 'password'
+            default: 'text', // One of: 'text', 'email', or 'password'
             type: String,
             required: true
         },

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -1,6 +1,6 @@
 <template>
-    <input :type="password ? 'password' : 'text'"
-        class="ff-input ff-text-input"
+    <input class="ff-input ff-text-input"
+        :type="type"
         :placeholder="placeholder"
         :disabled="disabled"
         :value="modelValue"
@@ -27,9 +27,10 @@ export default {
             default: 'normal',
             type: String // "small", "normal"
         },
-        password: {
-            default: false,
-            type: Boolean
+        type: {
+            default: 'text', // One of: 'text' or 'password'
+            type: String,
+            required: true
         },
         // v-model
         modelValue: {


### PR DESCRIPTION
Before this change TextInput components had a boolean field to set to
true for password fields. This change removes that field in favour of a
'type' field. This field can now be set to "text" (default), email, or
"password".