### PR TITLE
Add click-outside directive to Dropdown

### DIFF
--- a/src/components/form/Dropdown.vue
+++ b/src/components/form/Dropdown.vue
@@ -11,7 +11,7 @@
             <template v-slot:icon-right><ChevronDownIcon /></template>
         </ff-button>
         <template v-if="isOpen">
-            <div class="ff-dropdown-options" v-click-outside='close' :class="{'ff-dropdown-options--full-width': dropdownStyle === 'select', 'ff-dropdown-options--fit': dropdownStyle === 'button', 'ff-dropdown-options--align-left': optionsAlign === 'left', 'ff-dropdown-options--align-right': optionsAlign === 'right'}">
+            <div class="ff-dropdown-options" v-click-outside="close" :class="{'ff-dropdown-options--full-width': dropdownStyle === 'select', 'ff-dropdown-options--fit': dropdownStyle === 'button', 'ff-dropdown-options--align-left': optionsAlign === 'left', 'ff-dropdown-options--align-right': optionsAlign === 'right'}">
                 <slot></slot>
             </div>
         </template>

--- a/src/components/form/Dropdown.vue
+++ b/src/components/form/Dropdown.vue
@@ -10,9 +10,11 @@
             {{ placeholder }}
             <template v-slot:icon-right><ChevronDownIcon /></template>
         </ff-button>
-        <div class="ff-dropdown-options" :class="{'ff-dropdown-options--full-width': dropdownStyle === 'select', 'ff-dropdown-options--fit': dropdownStyle === 'button', 'ff-dropdown-options--align-left': optionsAlign === 'left', 'ff-dropdown-options--align-right': optionsAlign === 'right'}">
-            <slot></slot>
-        </div>
+        <template v-if="isOpen">
+            <div class="ff-dropdown-options" v-click-outside='close' :class="{'ff-dropdown-options--full-width': dropdownStyle === 'select', 'ff-dropdown-options--fit': dropdownStyle === 'button', 'ff-dropdown-options--align-left': optionsAlign === 'left', 'ff-dropdown-options--align-right': optionsAlign === 'right'}">
+                <slot></slot>
+            </div>
+        </template>
     </div>
 </template>
 
@@ -60,6 +62,9 @@ export default {
     methods: {
         open: function () {
             this.isOpen = !this.isOpen
+        },
+        close: function () {
+            this.isOpen = false
         }
     }
 }

--- a/src/directives.js
+++ b/src/directives.js
@@ -1,0 +1,5 @@
+import FFClickOutside from './directives/ClickOutside.js'
+
+export default {
+    FFClickOutside
+}

--- a/src/directives/ClickOutside.js
+++ b/src/directives/ClickOutside.js
@@ -1,0 +1,32 @@
+const instances = new Map()
+
+/**
+ * Adds a `v-click-outside` directive that can be used to trigger a callback when
+ * the user clicks outside of the element.
+ *
+ * Used by Dropdown to close its menu when the user clicks out
+ */
+
+const directive = {
+    name: 'click-outside',
+    mounted (element, options) {
+        const handler = function (evt) {
+            if (!evt.target !== element && !element.contains(evt.target)) {
+                return options.value()
+            } else {
+                return null
+            }
+        }
+        document.addEventListener('click', handler, true)
+        instances.set(element, handler)
+    },
+    unmounted (element) {
+        const handler = instances.get(element)
+        if (handler) {
+            document.removeEventListener('click', handler, true)
+        }
+        instances.delete(element)
+    }
+}
+
+export default directive

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-prototype-builtins */
+import directives from './directives'
 import components from './components'
-
 import './index.scss'
 
 const plugin = {
@@ -9,6 +9,12 @@ const plugin = {
             if (components.hasOwnProperty(prop)) {
                 const component = components[prop]
                 Vue.component(component.name, component)
+            }
+        }
+        for (const prop in directives) {
+            if (directives.hasOwnProperty(prop)) {
+                const directive = directives[prop]
+                Vue.directive(directive.name, directive)
             }
         }
     }


### PR DESCRIPTION
Fixes #16 

Today I have learnt about creating custom Vue directives.

This PR adds a `v-click-outside` directive and applies it to the `Dropdown` list of options - so the dropdown closes when you click away.

A not ideal side effect is that the dropdown button no longer acts as a toggle - click it with the menu open keeps the menu open (because `v-click-outside` is triggered that closes the menu, then the button click fires which opens it again).

Given a choice of the two, I prefer closing the menu when clicking away.