### PR TITLE
Ensure ff-dialog doesn't extend off screen

### DIFF
--- a/src/components/DialogBox.vue
+++ b/src/components/DialogBox.vue
@@ -2,7 +2,7 @@
     <div class="ff-dialog-container" :class="'ff-dialog-container--' + (open ? 'open' : 'closed')">
         <div class="ff-dialog-box">
             <div class="ff-dialog-header">{{ header }}</div>
-            <div class="ff-dialog-body" ref='body'>
+            <div class="ff-dialog-body" ref="body">
                 <div class="ff-dialog-content">
                     <slot></slot>
                 </div>

--- a/src/components/DialogBox.vue
+++ b/src/components/DialogBox.vue
@@ -2,16 +2,14 @@
     <div class="ff-dialog-container" :class="'ff-dialog-container--' + (open ? 'open' : 'closed')">
         <div class="ff-dialog-box">
             <div class="ff-dialog-header">{{ header }}</div>
-            <div class="ff-dialog-body" ref="body">
-                <div class="ff-dialog-content">
-                    <slot></slot>
-                </div>
-                <div class="ff-dialog-actions">
-                    <slot name="actions">
-                        <ff-button @click="$emit('cancel')" kind="secondary">Cancel</ff-button>
-                        <ff-button @click="$emit('confirm')">Confirm</ff-button>
-                    </slot>
-                </div>
+            <div class="ff-dialog-content" ref="content">
+                <slot></slot>
+            </div>
+            <div class="ff-dialog-actions">
+                <slot name="actions">
+                    <ff-button @click="$emit('cancel')" kind="secondary">Cancel</ff-button>
+                    <ff-button @click="$emit('confirm')">Confirm</ff-button>
+                </slot>
             </div>
         </div>
         <div class="ff-dialog-backdrop">
@@ -35,7 +33,7 @@ export default {
     },
     watch: {
         open: function () {
-            this.$refs.body.scrollTop = 0
+            this.$refs.content.scrollTop = 0
         }
     },
     emits: ['cancel', 'confirm']

--- a/src/components/DialogBox.vue
+++ b/src/components/DialogBox.vue
@@ -2,14 +2,16 @@
     <div class="ff-dialog-container" :class="'ff-dialog-container--' + (open ? 'open' : 'closed')">
         <div class="ff-dialog-box">
             <div class="ff-dialog-header">{{ header }}</div>
-            <div class="ff-dialog-content">
-                <slot></slot>
-            </div>
-            <div class="ff-dialog-actions">
-                <slot name="actions">
-                    <ff-button @click="$emit('cancel')" kind="secondary">Cancel</ff-button>
-                    <ff-button @click="$emit('confirm')">Confirm</ff-button>
-                </slot>
+            <div class="ff-dialog-body">
+                <div class="ff-dialog-content">
+                    <slot></slot>
+                </div>
+                <div class="ff-dialog-actions">
+                    <slot name="actions">
+                        <ff-button @click="$emit('cancel')" kind="secondary">Cancel</ff-button>
+                        <ff-button @click="$emit('confirm')">Confirm</ff-button>
+                    </slot>
+                </div>
             </div>
         </div>
         <div class="ff-dialog-backdrop">

--- a/src/components/DialogBox.vue
+++ b/src/components/DialogBox.vue
@@ -2,7 +2,7 @@
     <div class="ff-dialog-container" :class="'ff-dialog-container--' + (open ? 'open' : 'closed')">
         <div class="ff-dialog-box">
             <div class="ff-dialog-header">{{ header }}</div>
-            <div class="ff-dialog-body">
+            <div class="ff-dialog-body" ref='body'>
                 <div class="ff-dialog-content">
                     <slot></slot>
                 </div>
@@ -31,6 +31,11 @@ export default {
         header: {
             type: String,
             default: 'Dialog Box'
+        }
+    },
+    watch: {
+        open: function () {
+            this.$refs.body.scrollTop = 0
         }
     },
     emits: ['cancel', 'confirm']

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -383,7 +383,8 @@ li.ff-list-item {
   z-index: 2;
   width: 100%;
   max-width: 42rem;
-  max-height: 100%;
+  margin-top: 60px;
+  max-height: calc(100% - 84px);
   display: flex;
   flex-direction: column;
   background-color: $ff-white;
@@ -397,16 +398,14 @@ li.ff-list-item {
       color: $ff-white;
       font-weight: 600;
     }
-    &-body {
-      overflow-y: auto;
-    }
     &-content {
       padding: $ff-funit-lg;
+      overflow-y: auto;
     }
     &-actions {
       display: flex;
       justify-content: flex-end;
-      padding: 0 $ff-unit-lg $ff-unit-lg $ff-unit-lg;
+      padding: $ff-unit-md $ff-unit-lg $ff-unit-lg $ff-unit-lg;
       .ff-btn {
         margin-left: $ff-funit-md;
       }

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -383,6 +383,9 @@ li.ff-list-item {
   z-index: 2;
   width: 100%;
   max-width: 42rem;
+  max-height: 100%;
+  display: flex;
+  flex-direction: column;
   background-color: $ff-white;
   .ff-dialog {
     &-header {
@@ -393,6 +396,9 @@ li.ff-list-item {
       padding: 0 $ff-unit-lg;
       color: $ff-white;
       font-weight: 600;
+    }
+    &-body {
+      overflow-y: auto;
     }
     &-content {
       padding: $ff-funit-lg;


### PR DESCRIPTION
If a dialog has a lot of vertical content, then the current dialog expands off the top/bottom of the screen and the off-screen content cannot be reached.

This PR constrains the dialog to not expand off screen and makes the body scrollable if needed.

It also ensures the body is scrolled to the top whenever the dialog is opened.


Just to add - having very log dialogs isn't ideal, but even with smaller dialogs on small screens it will be an issue.