### PR TITLE
Bind button type to property

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -1,5 +1,5 @@
 <template>
-    <button class="ff-btn transition-fade--color" type="button" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" @click="go()">
+    <button class="ff-btn transition-fade--color" :type="type" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" @click="go()">
         <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
             <slot name="icon-left"></slot>
         </span>


### PR DESCRIPTION
Closes #12 

A quick 1-line change to bind the defined `type` property on the component through to the button itself.