### PR TITLE
Nest show/close functionality inside dialog box & add "kind" property to simplify API for delete use case

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -227,13 +227,13 @@
                 <props-table :rows="groups['dialog'].components[0].props"></props-table>
                 <h3>Emits:</h3>
                 <events-table :rows="groups['dialog'].components[0].emits"></events-table>
+                <h3>Slots:</h3>
+                <slots-table :rows="groups['dialog'].components[0].slots"></slots-table>
                 <h3>Examples:</h3>
                 <div class="examples">
                     <div class="example">
-                        <ff-button @click="models.showDialog = !models.showDialog">Show Dialog</ff-button>
-                        <ff-dialog :open="models.showDialog" header="My Dialog Box"
-                            @cancel="models.showDialog = false"
-                            @confirm="models.showDialog = false">
+                        <ff-button @click="$refs['dialog0'].show()">Show Dialog</ff-button>
+                        <ff-dialog ref="dialog0" header="My Dialog Box">
                             <p style="margin-bottom: 12px">The main message for the dialog box goes here. We can put any elements we like here.
                             For example, a text input:</p>
                             <ff-text-input placeholder="My Text Input"/>
@@ -241,19 +241,25 @@
                         <code>{{ groups['dialog'].components[0].examples[0].code }}</code>
                     </div>
                     <div class="example">
-                        <ff-button @click="models.showDialog1 = !models.showDialog1">Show Delete Dialog</ff-button>
-                        <ff-dialog :open="models.showDialog1" header="My Other Dialog Box"
-                            @cancel="models.showDialog1 = false"
-                            @confirm="models.showDialog1 = false">
-                            <template v-slot:default>
-                                Are you sure you want to delete this?
-                            </template>
-                            <template v-slot:actions>
-                                <ff-button kind="secondary" @click="models.showDialog1 = false">Cancel</ff-button>
-                                <ff-button kind="danger" @click="models.showDialog1 = false">Delete</ff-button>
-                            </template>
+                        <ff-button @click="$refs['dialog1'].show()">Show Delete Dialog</ff-button>
+                        <ff-dialog ref="dialog1" header="My Other Dialog Box" confirm-label="Delete" kind="danger">
+                            Are you sure you want to delete this?
                         </ff-dialog>
                         <code>{{ groups['dialog'].components[0].examples[1].code }}</code>
+                    </div>
+                    <div class="example">
+                        <ff-button @click="$refs['dialog2'].show()">Show Custom Dialog</ff-button>
+                        <ff-dialog ref="dialog2" header="My Custom Dialog Box">
+                            <template v-slot:default>
+                                Note we can override the actions too, but need to include close logic
+                            </template>
+                            <template v-slot:actions>
+                                <ff-button kind="secondary" @click="$refs['dialog2'].close()">Secondary 1</ff-button>
+                                <ff-button kind="secondary" @click="$refs['dialog2'].close()">Secondary 2</ff-button>
+                                <ff-button @click="$refs['dialog2'].close()">Confirm</ff-button>
+                            </template>
+                        </ff-dialog>
+                        <code>{{ groups['dialog'].components[0].examples[2].code }}</code>
                     </div>
                 </div>
             </div>
@@ -541,8 +547,6 @@ export default {
         return {
             theme: 'light',
             models: {
-                showDialog: false,
-                showDialog1: false,
                 textInput0: '',
                 dropdown0: null,
                 dropdown1: null,

--- a/docs/data/dialog.docs.json
+++ b/docs/data/dialog.docs.json
@@ -5,27 +5,40 @@
     "components": [{
         "name": "ff-dialog",
         "examples": [{
-            "code": "<ff-dialog :open=\"isOpen\" header=\"My Dialog Box\" @cancel=\"isOpen = false\" @confirm=\"isOpen = false\">\n\t<p style=\"margin-bottom: 12px\">\n\t\tThe main message for the dialog box goes here.\n\t\tWe can put any elements we like here. For example, a text input:\n\t</p>\n\t<ff-text-input placeholder=\"My Text Input\"/>\n</ff-dialog>"
+            "code": "<ff-button @click=\"$refs['dialog0'].show()\">Show Dialog</ff-button>\n<ff-dialog ref=\"dialog0\" header=\"My Dialog Box\" @confirm=\"doSomething()\">\n\t<p style=\"margin-bottom: 12px\">\n\t\tThe main message for the dialog box goes here.\n\t\tWe can put any elements we like here. For example, a text input:\n\t</p>\n\t<ff-text-input placeholder=\"My Text Input\"/>\n</ff-dialog>"
         }, {
-            "code": "<ff-dialog :open=\"isOpen\" header=\"My Other Dialog Box\">\n\t<template v-slot:default>\n\t\tAre you sure you want to delete this?\n\t</template>\n\t<template v-slot:actions>\n\t\t<ff-button kind=\"secondary\" @click=\"models.showDialog1 = false\">Cancel</ff-button>\n\t\t<ff-button kind=\"danger\" @click=\"models.showDialog1 = false\">Delete</ff-button>\n\t</template>\n</ff-dialog>"
+            "code": "<ff-button @click=\"$refs['dialog1'].show()\">Show Delete Dialog</ff-button>\n<ff-dialog ref=\"dialog1\" header=\"My Other Dialog Box\" @confirm=\"doSomething()\" confirm-label=\"Delete\" kind=\"danger\">\n\tAre you sure you want to delete this?\n</ff-dialog>"
+        }, {
+            "code": "<ff-button @click=\"$refs['dialog2'].show()\">Show Custom Dialog</ff-button>\n<ff-dialog ref=\"dialog2\" header=\"My Custom Dialog Box\">\n\t<template v-slot:default>\n\t\tNote we can override the actions too, but need to include close logic\n\t</template>\n\t<template v-slot:actions>\n\t\t<ff-button kind=\"secondary\" @click=\"$refs['dialog2'].close();doSecondaryAction1()\">Secondary 1</ff-button>\n\t\t<ff-button kind=\"secondary\" @click=\"$refs['dialog2'].close();doSecondaryAction2()\">Secondary 2</ff-button>\n\t\t<ff-button kind=\"danger\" @click=\"$refs['dialog2'].close();doSomething()\">Confirm</ff-button>\n\t</template>\n</ff-dialog>"
         }],
         "props": [{
-            "key": "open",
-            "default": "false",
-            "description": "<boolean> to define whether or not the dialog box should be displayed"
-        }, {
             "key": "header",
             "default": "Dialog Box",
             "description": "<string> to display in the main header bar of the dialog box"
+        }, {
+            "key": "confirm-label",
+            "default": "Confirm",
+            "description": "The text contained within the primary button of the dialog box."
+        }, {
+            "key": "kind",
+            "default": "primary",
+            "description": "The 'kind' to set on the primary button. Recommended as 'primary' or 'danger'."
+        }],
+        "slots": [{
+            "name": "default",
+            "description": "Define the core content of the dialog."
+        }, {
+            "name": "actions",
+            "description": "Replace the default secondary/primary button layout. In this case, @confirm and @cancel will not emit."
         }],
         "emits": [{
             "event": "confirm",
             "example": null,
-            "description": "When the default, primary action button is selected, this event is triggered."
+            "description": "When the primary action button is selected, this event is triggered."
         }, {
             "event": "cancel",
             "example": null,
-            "description": "When the default, secondary action button is selected, this event is triggered."
+            "description": "When the secondary action button is selected, this event is triggered."
         }]
     }]
 }

--- a/src/components/DialogBox.vue
+++ b/src/components/DialogBox.vue
@@ -7,8 +7,8 @@
             </div>
             <div class="ff-dialog-actions">
                 <slot name="actions">
-                    <ff-button @click="$emit('cancel')" kind="secondary">Cancel</ff-button>
-                    <ff-button @click="$emit('confirm')">Confirm</ff-button>
+                    <ff-button @click="cancel()" kind="secondary">Cancel</ff-button>
+                    <ff-button @click="confirm()" :kind="kind">{{ confirmLabel }}</ff-button>
                 </slot>
             </div>
         </div>
@@ -21,14 +21,19 @@
 <script>
 export default {
     name: 'ff-dialog',
+    emits: ['cancel', 'confirm'],
     props: {
-        open: {
-            type: Boolean,
-            default: false
-        },
         header: {
             type: String,
             default: 'Dialog Box'
+        },
+        confirmLabel: {
+            type: String,
+            default: 'Confirm'
+        },
+        kind: {
+            type: String,
+            default: 'primary'
         }
     },
     watch: {
@@ -36,6 +41,26 @@ export default {
             this.$refs.content.scrollTop = 0
         }
     },
-    emits: ['cancel', 'confirm']
+    data () {
+        return {
+            open: false
+        }
+    },
+    methods: {
+        show () {
+            this.open = true
+        },
+        close () {
+            this.open = false
+        },
+        cancel () {
+            this.close()
+            this.$emit('cancel')
+        },
+        confirm () {
+            this.close()
+            this.$emit('confirm')
+        }
+    }
 }
 </script>


### PR DESCRIPTION
Part of the foundation for #26 

<img width="955" alt="Screenshot 2022-07-28 at 13 11 35" src="https://user-images.githubusercontent.com/99246719/181501891-ea416012-a300-484e-9323-0e3eaaf69692.png">

For comparison, what is now example 2, used to look like what is now example 3. The option to have complete control over the slots remains ,but I've simplified the requirement to have the show/close logic in every instance of the dialog, as well as making it simpler to create the "Delete" dialogs without having to define the `<template v-slot:actions>` every time.