### PR TITLE
permit ff-dialog to be kept open upon confirm

### DIFF
--- a/src/components/DialogBox.vue
+++ b/src/components/DialogBox.vue
@@ -38,6 +38,10 @@ export default {
         kind: {
             type: String,
             default: 'primary'
+        },
+        closeOnConfirm: {
+            type: Boolean,
+            default: true
         }
     },
     watch: {
@@ -62,7 +66,9 @@ export default {
             this.$emit('cancel')
         },
         confirm () {
-            this.close()
+            if (this.closeOnConfirm) {
+                this.close()
+            }
             this.$emit('confirm')
         }
     }


### PR DESCRIPTION
fixes #48

permits dialog to remain open in cases where an async action fails

