### PR TITLE
Allow data-table key and map props reference nested properties

### DIFF
--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -139,8 +139,8 @@ export default {
             if (this.sort.key) {
                 return rows.sort((a, b) => {
                     // catch the undefined use case, by making undefined = 0
-                    const aValue = a[this.sort.key] || 0
-                    const bValue = b[this.sort.key] || 0
+                    const aValue = this.lookupProperty(a, this.sort.key) || 0
+                    const bValue = this.lookupProperty(b, this.sort.key) || 0
                     if (this.sort.order === 'asc') {
                         if (aValue < bValue) {
                             return 1
@@ -235,6 +235,22 @@ export default {
         },
         resetOrder () {
             this.sort.order = this.orders[0]
+        },
+        lookupProperty (obj, property) {
+            const parts = property.split('.')
+            if (parts.length === 1) {
+                return obj[property]
+            } else {
+                while (parts.length > 0) {
+                    const part = parts.shift()
+                    if (Object.hasOwn(obj, part)) {
+                        obj = obj[part]
+                    } else {
+                        return undefined
+                    }
+                }
+            }
+            return obj
         }
     },
     components: {

--- a/src/components/data-table/DataTableRow.vue
+++ b/src/components/data-table/DataTableRow.vue
@@ -53,7 +53,7 @@ export default {
         },
         getCellData: function (data, col) {
             if (col.component?.map) {
-                // create a clone of data in case we override existing proeprties
+                // create a clone of data in case we override existing properties
                 // this is okay, as long as it's contained within a cell.
                 // e.g. a component may look for an "id" re: a user, but the whole row
                 // may be linked to a template, which has it's own "id"
@@ -61,12 +61,28 @@ export default {
                 // map the relevant properties in accordance to the provided map
                 const dataMap = col.component?.map
                 for (const [to, from] of Object.entries(dataMap)) {
-                    cell[to] = cell[from]
+                    cell[to] = this.lookupProperty(cell, from)
                 }
                 return cell
             } else {
                 return data
             }
+        },
+        lookupProperty (obj, property) {
+            const parts = property.split('.')
+            if (parts.length === 1) {
+                return obj[property]
+            } else {
+                while (parts.length > 0) {
+                    const part = parts.shift()
+                    if (Object.hasOwn(obj, part)) {
+                        obj = obj[part]
+                    } else {
+                        return undefined
+                    }
+                }
+            }
+            return obj
         }
     }
 }


### PR DESCRIPTION
Closes #43 

This PR allows the `key` and `map` properties in a data table column to reference nested properties.

For example, given an array of items that look like this:
```
{
   id: 123,
   name: 'a project',
   team: {
      id: 456,
      name: 'a team'
   }
}
```

The column definitions for the data table can now do:

```
[
   { label: 'Project Name', key: 'name', sortable: true },
   { label: 'Team Name', key: 'team.name', sortable: true }
]
```

When a custom component is required for the cell, its `map` property can also reference nested props:

```
[
   { label: 'Project Name', key: 'name', sortable: true },
   {
      label: 'Team Name',
      key: 'team.name',
      sortable: true,
      component: {
         is: markRaw(TeamCell),
         map: {
            id: 'team.id',
            name: 'team.name'
         }
      }
   }
]
```

Note this doesn't change the filtering functionality - it still only filters the table based on the top-level properties.