### PR TITLE
Add focus and blur method to text inputs

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -300,13 +300,15 @@
                 <h2 ref="ff-text-input"><pre>ff-text-input</pre></h2>
                 <h3>Properties:</h3>
                 <props-table :rows="cGroups['input'].components[0].props"></props-table>
+                <h3>Methods:</h3>
+                <methods-table :rows="cGroups['input'].components[0].methods" @callMethod="this.$refs['text-input']?.[$event]()"></methods-table>
                 <h3>Slots:</h3>
                 <slots-table :rows="cGroups['input'].components[0].slots"></slots-table>
                 <h3>Examples:</h3>
                 <div class="examples">
                     <div class="example">
                         <h5>Simple Text Input</h5>
-                        <ff-text-input placeholder="Insert something here..." v-model="models.textInput0"/>
+                        <ff-text-input placeholder="Insert something here..." v-model="models.textInput0" ref="text-input"/>
                         {{ models.textInput0 }}
                         <code>{{ cGroups['input'].components[0].examples[0].code }}</code>
                     </div>
@@ -578,8 +580,9 @@
 
 import _ from 'underscore'
 
-import PropsTable from './components/PropsTable.vue'
 import EventsTable from './components/EventsTable.vue'
+import MethodsTable from './components/MethodsTable.vue'
+import PropsTable from './components/PropsTable.vue'
 import SlotsTable from './components/SlotsTable.vue'
 
 import buttonDocs from './data/button.docs.json'
@@ -600,8 +603,9 @@ import { markRaw } from '@vue/reactivity'
 export default {
     name: 'DesignLanguage',
     components: {
-        PropsTable,
         EventsTable,
+        MethodsTable,
+        PropsTable,
         SlotsTable,
         // icons
         PlusSmIcon,

--- a/docs/components/MethodsTable.vue
+++ b/docs/components/MethodsTable.vue
@@ -1,0 +1,30 @@
+<template>
+    <table class="docs-table props-table">
+        <tbody>
+            <tr>
+                <th>Method</th>
+                <th>Description</th>
+                <th>Try</th>
+            </tr>
+            <tr v-for="r in rows" :key="r.key">
+                <th><pre>{{ r.name }}</pre></th>
+                <td>{{ r.description }}</td>
+                <td><ff-button @click="callMethod(r.name)">{{r.name}}</ff-button></td>
+            </tr>
+        </tbody>
+    </table>
+</template>
+
+<script>
+export default {
+    name: 'MethodsTable',
+    props: {
+        rows: Array
+    },
+    methods: {
+        callMethod (name) {
+            this.$emit('callMethod', name)
+        }
+    }
+}
+</script>

--- a/docs/data/input.docs.json
+++ b/docs/data/input.docs.json
@@ -6,13 +6,13 @@
         "examples": [{
             "code": "<ff-text-input v-model=\"myVar\" placeholder=\"Insert something here...\" />"
         }, {
-            "code": "<ff-text-input type\"password\" v-model=\"myPassword\" placeholder=\"Password goes here...\" />"
+            "code": "<ff-text-input type=\"password\" v-model=\"myPassword\" placeholder=\"Password goes here...\" />"
         }, {
-            "code": "<ff-text-input type\"email\" v-model=\"myEmail\" />"
+            "code": "<ff-text-input type=\"email\" v-model=\"myEmail\" />"
         }, {
-            "code": "<ff-text-input type\"email\" v-model=\"myEmail\">\n\t<template v-slot:icon><SearchIcon/></template>\n</ff-text-input>"
+            "code": "<ff-text-input type=\"email\" v-model=\"myEmail\">\n\t<template v-slot:icon><SearchIcon/></template>\n</ff-text-input>"
         }, {
-            "code": "<ff-text-input type\"email\" v-model=\"myEmail\" :error=\"'This is the error.'\"></ff-text-input>"
+            "code": "<ff-text-input type=\"email\" v-model=\"myEmail\" :error=\"'This is the error.'\"></ff-text-input>"
         }],
         "props": [{
             "key": "disabled",

--- a/docs/data/input.docs.json
+++ b/docs/data/input.docs.json
@@ -31,6 +31,14 @@
             "default": "false",
             "description": "Anything other than null/undefined will result in the error state being visualised. Error message can be displayed manually with a <label class=\"ff-error-inline\">"
         }],
+        "methods": [{
+            "name": "focus",
+            "description": "Focuses on the element"
+        },{
+            "name": "blur",
+            "description": "Removes focus from the element"
+        }
+    ],
         "slots": [{
             "name": "icon",
             "description": "Pass in an icon to this slot to render it on hte left-side of the input field"

--- a/src/components/form/TextInput.vue
+++ b/src/components/form/TextInput.vue
@@ -6,6 +6,7 @@
             :placeholder="placeholder"
             :disabled="disabled"
             :value="modelValue"
+            ref="input"
             @change="$emit('update:modelValue', $event.target.value)"
             @input="$emit('update:modelValue', $event.target.value)"
             @enter="$emit('enter', $event)"
@@ -44,6 +45,14 @@ export default {
         modelValue: {
             type: String,
             default: ''
+        }
+    },
+    methods: {
+        focus () {
+            this.$refs.input?.focus()
+        },
+        blur () {
+            this.$refs.input?.blur()
         }
     }
 }


### PR DESCRIPTION
Part of https://github.com/flowforge/forge-ui-components/issues/42, adds the focus method to text inputs

![Screenshot 2022-10-18 at 11 21 21](https://user-images.githubusercontent.com/507155/196390931-1d3cdc1f-d256-447f-bb68-6df23fd31d83.png)
