### PR TITLE
Use multiply by 0.5 instead of /

### DIFF
--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -810,13 +810,13 @@ $countdown_size: 20px;
 
 .countdown-spinner {
   transform-origin: 100% 50%;
-  border-radius: ($countdown_size/2) 0 0 ($countdown_size/2);
+  border-radius: ($countdown_size*0.5) 0 0 ($countdown_size*0.5);
   z-index: 200;
   border-right: none;
 }
 
 .countdown-filler {
-  border-radius: 0 ($countdown_size/2) ($countdown_size/2) 0;
+  border-radius: 0 ($countdown_size*0.5) ($countdown_size*0.5) 0;
   z-index: 100;
   border-left: none;
   left: 50%;


### PR DESCRIPTION
Slash as division is deprecated in Sass: https://sass-lang.com/documentation/breaking-changes/slash-div

If/when the project migrated to dart-sass (which it should since node-sass is [long deprecated](https://sass-lang.com/blog/libsass-is-deprecated) - see #64 ), this division will lead to errors.