### PR TITLE
Click events in kebab menu's should not bubble

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -153,9 +153,9 @@
                         </p>
                         <ff-data-table :columns="data.table0.columns" :rows="data.table0.rows">
                             <template v-slot:context-menu>
-                                <ff-list-item label="Option 1" @click.stop="doSomething"/>
-                                <ff-list-item label="Option 2" @click.stop="doSomething"/>
-                                <ff-list-item label="Option 3" @click.stop="doSomething"/>
+                                <ff-list-item label="Option 1" @click.stop=""/>
+                                <ff-list-item label="Option 2" @click.stop=""/>
+                                <ff-list-item label="Option 3" @click.stop=""/>
                             </template>
                         </ff-data-table>
                         <code style="margin-top: 24px;">{{ cGroups['data-table'].components[0].examples[2].code }}</code>
@@ -846,6 +846,9 @@ export default {
         },
         pretty: function (value) {
             return JSON.stringify(value, null, 2)
+        },
+        rowSelected () {
+            console.log('row selected')
         }
     }
 }

--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -147,11 +147,15 @@
                     </div>
                     <div class="example">
                         <h5>Example 3: Context Menu</h5>
+                        <p style="margin-bottom: 12px;">Note, the
+                            <pre style="display:inline;">.stop</pre> event modifier on the event handlers. This is important if
+                            <pre style="display:inline;">:rows-selectable="true"</pre> to prevent the click event bubbling up to the row.
+                        </p>
                         <ff-data-table :columns="data.table0.columns" :rows="data.table0.rows">
                             <template v-slot:context-menu>
-                                <ff-list-item label="Option 1" @click="doSomething"/>
-                                <ff-list-item label="Option 2" @click="doSomething"/>
-                                <ff-list-item label="Option 3" @click="doSomething"/>
+                                <ff-list-item label="Option 1" @click.stop="doSomething"/>
+                                <ff-list-item label="Option 2" @click.stop="doSomething"/>
+                                <ff-list-item label="Option 3" @click.stop="doSomething"/>
                             </template>
                         </ff-data-table>
                         <code style="margin-top: 24px;">{{ cGroups['data-table'].components[0].examples[2].code }}</code>

--- a/docs/data/table.docs.json
+++ b/docs/data/table.docs.json
@@ -9,7 +9,7 @@
         }, {
             "code": "<ff-data-table :columns=\"cols\" :rows=\"rows\" :rows-selectable=\"true\" @row-selected=\"doSomething\"></ff-data-table>"
         }, {
-            "code": "<ff-data-table :columns=\"cols\" :rows=\"rows\">\n\t<template v-slot:context-menu=\"{row}\">\n\t\t<ff-list-item label=\"Option 1\" @click=\"doSomething(row)\"/>\n\t\t<ff-list-item label=\"Option 2\" @click=\"doSomething(row)\"/>\n\t\t<ff-list-item label=\"Option 3\" @click=\"doSomething(row)\"/>\n\t</template>\n</ff-data-table>"
+            "code": "<ff-data-table :columns=\"cols\" :rows=\"rows\">\n\t<template v-slot:context-menu=\"{row}\">\n\t\t<ff-list-item label=\"Option 1\" @click.stop=\"doSomething(row)\"/>\n\t\t<ff-list-item label=\"Option 2\" @click.stop=\"doSomething(row)\"/>\n\t\t<ff-list-item label=\"Option 3\" @click.stop=\"doSomething(row)\"/>\n\t</template>\n</ff-data-table>"
         }, {
             "code": "<ff-data-table :columns=\"cols\" :rows=\"rows\" :show-search=\"true\"\n\tsearch-placeholder=\"Search here...\" v-model:search=\"search\">\n\t<template v-slot:actions>\n\t\t<ff-button>Press Me!</ff-button>\n\t\t<ff-button>Click Me!</ff-button>\n\t</template>\n</ff-data-table>"
         }, {

--- a/src/components/KebabMenu.vue
+++ b/src/components/KebabMenu.vue
@@ -2,8 +2,8 @@
     <div class="ff-kebab-menu" :class="{'active': open}">
         <!-- using this v-if hack in order to enable both
         the button and click-outside to work when closing the menu -->
-        <DotsVerticalIcon v-if="!open" @click="openOptions()"/>
-        <DotsVerticalIcon v-if="open" @click="closeOptions()"/>
+        <DotsVerticalIcon v-if="!open" @click.stop="openOptions()"/>
+        <DotsVerticalIcon v-if="open" @click.stop="closeOptions()"/>
         <template v-if="open">
             <ul class="ff-kebab-options" :class="'ff-kebab-options--' + menuAlign"
                 v-click-outside="closeOptions">


### PR DESCRIPTION
Fixes #58 

Two parts:

- Kebab menus are used by data-tables for the context menu, but the event bubble up to the row
- List items passed into the context menu slot, should always use `stop` to prevent events from bubbling  

![Screenshot 2022-10-19 at 10 02 57](https://user-images.githubusercontent.com/507155/196632685-a5460bce-d35e-4fe5-9490-8b140d1c61aa.png)
