### PR TITLE
Natural sorting of data-tables

### DIFF
--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -158,7 +158,7 @@ export default {
                         typeof aValue === 'boolean' &&
                         typeof bValue === 'boolean'
                     ) {
-                        return aValue === bValue ? 0 : aValue < bValue ? 1 : -1
+                        return aValue === bValue ? 0 : (aValue > bValue ? 1 : -1)
                     } else if (
                         typeof aValue === 'boolean' ||
                         typeof bValue === 'boolean'

--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -138,9 +138,10 @@ export default {
             const rows = this.filterRows([...this.rows])
             if (this.sort.key) {
                 return rows.sort((a, b) => {
-                    // catch the undefined use case, by making undefined = 0
-                    const aProp = this.lookupProperty(a, this.sort.key) || 0
-                    const bProp = this.lookupProperty(b, this.sort.key) || 0
+                    // Catch undefined and null, swapping to ''
+                    const aProp = this.lookupProperty(a, this.sort.key) ?? ''
+                    const bProp = this.lookupProperty(b, this.sort.key) ?? ''
+
 
                     // Ordering
                     const [aValue, bValue] =

--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -153,6 +153,19 @@ export default {
                             ? [aProp, bProp]
                             : [bProp, aProp]
 
+                    // Booleans are grouped together, sorted as booleans, not strings
+                    if (
+                        typeof aValue === 'boolean' &&
+                        typeof bValue === 'boolean'
+                    ) {
+                        return aValue === bValue ? 0 : aValue < bValue ? 1 : -1
+                    } else if (
+                        typeof aValue === 'boolean' ||
+                        typeof bValue === 'boolean'
+                    ) {
+                        return 1
+                    }
+
                     return collator.compare(aValue, bValue)
                 })
             } else {

--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -163,7 +163,7 @@ export default {
                         typeof aValue === 'boolean' ||
                         typeof bValue === 'boolean'
                     ) {
-                        return this.sort.order === 'asc' ? 1 : -1
+                        return this.sort.order === 'asc' ? -1 : 1
                     }
 
                     return collator.compare(aValue, bValue)

--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -163,7 +163,7 @@ export default {
                         typeof aValue === 'boolean' ||
                         typeof bValue === 'boolean'
                     ) {
-                        return 1
+                        return this.sort.order === 'asc' ? 1 : -1
                     }
 
                     return collator.compare(aValue, bValue)

--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -139,24 +139,22 @@ export default {
             if (this.sort.key) {
                 return rows.sort((a, b) => {
                     // catch the undefined use case, by making undefined = 0
-                    const aValue = this.lookupProperty(a, this.sort.key) || 0
-                    const bValue = this.lookupProperty(b, this.sort.key) || 0
-                    if (this.sort.order === 'asc') {
-                        if (aValue < bValue) {
-                            return 1
-                        } else if (aValue > bValue) {
-                            return -1
-                        } else {
-                            return 0
-                        }
+                    const aProp = this.lookupProperty(a, this.sort.key) || 0
+                    const bProp = this.lookupProperty(b, this.sort.key) || 0
+
+                    // Ordering
+                    const [aValue, bValue] =
+                        this.sort.order === 'asc'
+                            ? [aProp, bProp]
+                            : [bProp, aProp]
+
+                    if (aValue < bValue) {
+                        return 1
+                    } else if (aValue > bValue) {
+                        return -1
                     } else {
-                        if (aValue < bValue) {
-                            return -1
-                        } else if (aValue > bValue) {
-                            return 1
-                        } else {
-                            return 0
-                        }
+                        return 0
+                    }
                     }
                 })
             } else {

--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -142,6 +142,10 @@ export default {
                     const aProp = this.lookupProperty(a, this.sort.key) ?? ''
                     const bProp = this.lookupProperty(b, this.sort.key) ?? ''
 
+                    const collator = new Intl.Collator(undefined, {
+                        numeric: true,
+                        sensitivity: 'base'
+                    })
 
                     // Ordering
                     const [aValue, bValue] =
@@ -149,14 +153,7 @@ export default {
                             ? [aProp, bProp]
                             : [bProp, aProp]
 
-                    if (aValue < bValue) {
-                        return 1
-                    } else if (aValue > bValue) {
-                        return -1
-                    } else {
-                        return 0
-                    }
-                    }
+                    return collator.compare(aValue, bValue)
                 })
             } else {
                 return rows

--- a/tests/unit/data-table/DataTable.spec.js
+++ b/tests/unit/data-table/DataTable.spec.js
@@ -134,7 +134,7 @@ describe('DataTable', () => {
             ).toEqual(['device 21', 'device 3', 'device 1'])
         })
 
-        it('Treats null and undefined as equivalent to empty string', () => {
+        it('Treats null and undefined as equivalent to empty string ascending', () => {
             const localThis = {
                 lookupProperty: DataTable.methods.lookupProperty,
                 filterRows: DataTable.methods.filterRows,
@@ -154,6 +154,28 @@ describe('DataTable', () => {
             expect(
                 DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
             ).toEqual([undefined, null, '', 'apple', 'zebra'])
+        })
+
+        it('Treats null and undefined as equivalent to empty string descending', () => {
+            const localThis = {
+                lookupProperty: DataTable.methods.lookupProperty,
+                filterRows: DataTable.methods.filterRows,
+                rows: [
+                    {},
+                    { value: 'zebra' },
+                    { value: null },
+                    { value: 'apple' },
+                    { value: '' }
+                ],
+                sort: {
+                    key: 'value',
+                    order: 'desc'
+                }
+            }
+
+            expect(
+                DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
+            ).toEqual(['zebra', 'apple', undefined, null, ''])
         })
 
         it('Sorts booleans descending', () => {

--- a/tests/unit/data-table/DataTable.spec.js
+++ b/tests/unit/data-table/DataTable.spec.js
@@ -1,0 +1,204 @@
+import DataTable from '@/components/data-table/DataTable.vue'
+
+describe('DataTable', () => {
+    describe('filteredRows', () => {
+        it('Sorts numbers descending', () => {
+            const localThis = {
+                lookupProperty: DataTable.methods.lookupProperty,
+                filterRows: DataTable.methods.filterRows,
+                rows: [
+                    { value: 15 },
+                    { value: 21 },
+                    { value: 9 },
+                    { value: 1 },
+                    { value: 4 },
+                    { value: 3 }
+                ],
+                sort: {
+                    key: 'value',
+                    order: 'desc'
+                }
+            }
+
+            expect(
+                DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
+            ).toEqual([21, 15, 9, 4, 3, 1])
+        })
+
+        it('Sorts numbers ascending', () => {
+            const localThis = {
+                lookupProperty: DataTable.methods.lookupProperty,
+                filterRows: DataTable.methods.filterRows,
+                rows: [
+                    { value: 21 },
+                    { value: 15 },
+                    { value: 9 },
+                    { value: 4 },
+                    { value: 3 },
+                    { value: 1 }
+                ],
+                sort: {
+                    key: 'value',
+                    order: 'asc'
+                }
+            }
+
+            expect(
+                DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
+            ).toEqual([1, 3, 4, 9, 15, 21])
+        })
+
+        it('Sorts strings ascending', () => {
+            const localThis = {
+                lookupProperty: DataTable.methods.lookupProperty,
+                filterRows: DataTable.methods.filterRows,
+                rows: [
+                    { value: 'apple' },
+                    { value: 'orange' },
+                    { value: 'zebra' },
+                    { value: 'Zebras' },
+                    { value: 'Apples' }
+                ],
+                sort: {
+                    key: 'value',
+                    order: 'asc'
+                }
+            }
+
+            expect(
+                DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
+            ).toEqual(['apple', 'Apples', 'orange', 'zebra', 'Zebras'])
+        })
+
+        it('Sorts strings descending', () => {
+            const localThis = {
+                lookupProperty: DataTable.methods.lookupProperty,
+                filterRows: DataTable.methods.filterRows,
+                rows: [
+                    { value: 'apple' },
+                    { value: 'orange' },
+                    { value: 'zebra' },
+                    { value: 'Zebras' },
+                    { value: 'Apples' }
+                ],
+                sort: {
+                    key: 'value',
+                    order: 'desc'
+                }
+            }
+
+            expect(
+                DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
+            ).toEqual(['Zebras', 'zebra', 'orange', 'Apples', 'apple'])
+        })
+
+        it('Sorts a mix of strings and numbers naturally ascending', () => {
+            const localThis = {
+                lookupProperty: DataTable.methods.lookupProperty,
+                filterRows: DataTable.methods.filterRows,
+                rows: [
+                    { value: '1 dog' },
+                    { value: 12 },
+                    { value: '21 dogs' },
+                    { value: '3 dogs' },
+                    { value: 30 }
+                ],
+                sort: {
+                    key: 'value',
+                    order: 'asc'
+                }
+            }
+
+            expect(
+                DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
+            ).toEqual(['1 dog', '3 dogs', 12, '21 dogs', 30])
+        })
+
+        it('Sorts a mix of strings and numbers naturally descending', () => {
+            const localThis = {
+                lookupProperty: DataTable.methods.lookupProperty,
+                filterRows: DataTable.methods.filterRows,
+                rows: [
+                    { value: 'device 1' },
+                    { value: 'device 3' },
+                    { value: 'device 21' }
+                ],
+                sort: {
+                    key: 'value',
+                    order: 'desc'
+                }
+            }
+
+            expect(
+                DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
+            ).toEqual(['device 21', 'device 3', 'device 1'])
+        })
+
+        it('Treats null and undefined as equivalent to empty string', () => {
+            const localThis = {
+                lookupProperty: DataTable.methods.lookupProperty,
+                filterRows: DataTable.methods.filterRows,
+                rows: [
+                    {},
+                    { value: 'zebra' },
+                    { value: null },
+                    { value: 'apple' },
+                    { value: '' }
+                ],
+                sort: {
+                    key: 'value',
+                    order: 'asc'
+                }
+            }
+
+            expect(
+                DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
+            ).toEqual([undefined, null, '', 'apple', 'zebra'])
+        })
+
+        it('Sorts booleans descending', () => {
+            const localThis = {
+                lookupProperty: DataTable.methods.lookupProperty,
+                filterRows: DataTable.methods.filterRows,
+                rows: [
+                    { value: true },
+                    { value: false },
+                    { value: true }
+                ],
+                sort: {
+                    key: 'value',
+                    order: 'desc'
+                }
+            }
+
+            expect(
+                DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
+            ).toEqual([false, true, true])
+        })
+
+        it('Groups booleans together by treating them as strings', () => {
+            const localThis = {
+                lookupProperty: DataTable.methods.lookupProperty,
+                filterRows: DataTable.methods.filterRows,
+                rows: [
+                    { value: true },
+                    { value: false },
+                    { value: true },
+                    { value: 'a-string' },
+                    { value: 'z-string' },
+                    { value: 2 },
+                    { value: 1 },
+                    { value: 0 }
+                ],
+                sort: {
+                    key: 'value',
+                    order: 'asc'
+                }
+            }
+
+            expect(
+                DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
+            ).toEqual([true, true, false, 0, 1, 2, 'a-string', 'z-string'])
+        })
+    })
+})

--- a/tests/unit/data-table/DataTable.spec.js
+++ b/tests/unit/data-table/DataTable.spec.js
@@ -240,7 +240,7 @@ describe('DataTable', () => {
 
             expect(
                 DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
-            ).toEqual([false, true, true, 0, 1, 2, 'a-string', 'z-string'])
+            ).toEqual([0, 1, 2, 'a-string', 'z-string', false, true, true])
         })
 
         it('Groups booleans together by treating them as strings descending', () => {
@@ -265,7 +265,7 @@ describe('DataTable', () => {
 
             expect(
                 DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
-            ).toEqual(['z-string', 'a-string', 2, 1, 0, true, true, false])
+            ).toEqual([true, true, false, 'z-string', 'a-string', 2, 1, 0])
         })
     })
 })

--- a/tests/unit/data-table/DataTable.spec.js
+++ b/tests/unit/data-table/DataTable.spec.js
@@ -195,10 +195,30 @@ describe('DataTable', () => {
 
             expect(
                 DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
+            ).toEqual([true, true, false])
+        })
+
+        it('Sorts booleans ascending', () => {
+            const localThis = {
+                lookupProperty: DataTable.methods.lookupProperty,
+                filterRows: DataTable.methods.filterRows,
+                rows: [
+                    { value: true },
+                    { value: false },
+                    { value: true }
+                ],
+                sort: {
+                    key: 'value',
+                    order: 'asc'
+                }
+            }
+
+            expect(
+                DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
             ).toEqual([false, true, true])
         })
 
-        it('Groups booleans together by treating them as strings', () => {
+        it('Groups booleans together by treating them as strings ascending', () => {
             const localThis = {
                 lookupProperty: DataTable.methods.lookupProperty,
                 filterRows: DataTable.methods.filterRows,
@@ -220,7 +240,8 @@ describe('DataTable', () => {
 
             expect(
                 DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
-            ).toEqual([true, true, false, 0, 1, 2, 'a-string', 'z-string'])
+            ).toEqual([false, true, true, 0, 1, 2, 'a-string', 'z-string'])
+        })
         })
     })
 })

--- a/tests/unit/data-table/DataTable.spec.js
+++ b/tests/unit/data-table/DataTable.spec.js
@@ -242,6 +242,30 @@ describe('DataTable', () => {
                 DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
             ).toEqual([false, true, true, 0, 1, 2, 'a-string', 'z-string'])
         })
+
+        it('Groups booleans together by treating them as strings descending', () => {
+            const localThis = {
+                lookupProperty: DataTable.methods.lookupProperty,
+                filterRows: DataTable.methods.filterRows,
+                rows: [
+                    { value: true },
+                    { value: false },
+                    { value: true },
+                    { value: 'a-string' },
+                    { value: 'z-string' },
+                    { value: 2 },
+                    { value: 1 },
+                    { value: 0 }
+                ],
+                sort: {
+                    key: 'value',
+                    order: 'desc'
+                }
+            }
+
+            expect(
+                DataTable.computed.filteredRows.call(localThis).map((row) => row.value)
+            ).toEqual(['z-string', 'a-string', 2, 1, 0, true, true, false])
         })
     })
 })


### PR DESCRIPTION
~**Warning:** Merge target is https://github.com/flowforge/forge-ui-components/pull/79 which should be merged first. Alternatively, the unit tests can be removed from this PR.~

Fixes #59 and implements more natural sorting for all data-tables by making use of the native [Intl.Collator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator), which has several advantages:

 - Sorting is based on the users locale conforming to their expectations
 - Handles accents and cases (e.g. `a ≠ b, a = á, a = A`) naturally rather than based on ASCII code
 - Strings containing numbers are sorted in a logical order (device 1, device 3, device 21)
 
Additionally, this PR adds a special case that groups booleans when sorting. Booleans render in the UI as a checkmark, and this looks out of place when treating the boolean as a string and ordering alphabetically (since you'd end up with `['apple', ✓, 'zebra']`).

See the unit tests for how this looks in practice

This might be easier to review commit by commit.
