### PR TITLE
Use smaller icons during sort

### DIFF
--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -22,9 +22,9 @@
                                 <!-- Internal div required to have flex w/sorting icons -->
                                 <div>
                                     {{ col.label }}
-                                    <SwitchVerticalIcon class="ff-icon" v-if="col.sortable && col.key !== sort.key"/>
-                                    <SortAscendingIcon class="ff-icon icon-sorted" v-if="col.sortable && col.key === sort.key && sort.order === 'asc'"/>
-                                    <SortDescendingIcon class="ff-icon icon-sorted" v-if="col.sortable && col.key === sort.key && sort.order === 'desc'"/>
+                                    <SwitchVerticalIcon class="ff-icon-sm" v-if="col.sortable && col.key !== sort.key"/>
+                                    <SortAscendingIcon class="ff-icon-sm icon-sorted" v-if="col.sortable && col.key === sort.key && sort.order === 'asc'"/>
+                                    <SortDescendingIcon class="ff-icon-sm icon-sorted" v-if="col.sortable && col.key === sort.key && sort.order === 'desc'"/>
                                 </div>
                             </ff-data-table-cell>
                             <ff-data-table-cell v-if="hasContextMenu"></ff-data-table-cell>


### PR DESCRIPTION
To address #39, using smaller icons rather than hiding the icons.

### Before
<img width="924" alt="Screenshot 2022-10-24 at 11 57 54" src="https://user-images.githubusercontent.com/507155/197501066-5c21ddf5-3a8e-42e6-a568-23f531d40166.png">

### After
<img width="926" alt="Screenshot 2022-10-24 at 11 57 38" src="https://user-images.githubusercontent.com/507155/197501068-e239e131-de14-4626-b975-5f89dbc703dc.png">
