### PR TITLE
Nested Search of Objects in Data Tables

### DIFF
--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -191,28 +191,32 @@ export default {
     methods: {
         filterRows (rows) {
             const search = this.internalSearch
-            if (search) {
-                const filtered = rows.filter((cell, index) => {
-                    const props = Object.entries(cell)
-                    for (let i = 0; i < props.length; i++) {
-                        let [prop, value] = props[i]
-                        if (!this.searchFields || (this.searchFields?.indexOf(prop) > -1)) {
-                            if (typeof value === 'number') {
-                                value = value.toString()
-                            }
-                            if (typeof value === 'string') {
-                                if (value.toLowerCase().indexOf(search.toLowerCase()) > -1) {
-                                    return true
-                                }
-                            }
-                        }
-                    }
-                    return false
-                })
-                return filtered
-            } else {
+            if (!search) {
                 return rows
             }
+
+            const searchString = search.toLowerCase()
+
+            return rows.filter((row) =>
+                Object.entries(row).some(([propName, propValue]) => {
+                    // Skip props that aren't being considered
+                    if (
+                        this.searchFields?.length > 0 && !this.searchFields.includes(propName)
+                    ) {
+                        return false
+                    }
+
+                    // Skip non numeric strings (bool, undefined, null, etc)
+                    if (typeof propValue === 'number') {
+                        propValue = propValue.toString()
+                    }
+                    if (typeof propValue !== 'string') {
+                        return false
+                    }
+
+                    return propValue.toLowerCase().includes(searchString)
+                })
+            )
         },
         rowClick (row) {
             if (this.rowsSelectable) {

--- a/tests/unit/data-table/DataTable.spec.js
+++ b/tests/unit/data-table/DataTable.spec.js
@@ -1,6 +1,125 @@
 import DataTable from '@/components/data-table/DataTable.vue'
 
 describe('DataTable', () => {
+    describe('filterRows', () => {
+        it('searches all properties and returns matching subset of rows', () => {
+            const rows = [{
+                name: 'Apple',
+                desc: 'Is Green'
+            }, {
+                name: 'Banana',
+                desc: 'Not as good as an Apple'
+            }, {
+                name: 'Pear',
+                color: 'Green'
+            }]
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: 'Apple' }, rows)
+            ).toEqual([{
+                name: 'Apple',
+                desc: 'Is Green'
+            }, {
+                name: 'Banana',
+                desc: 'Not as good as an Apple'
+            }])
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: 'Green' }, rows)
+            ).toEqual([{
+                name: 'Apple',
+                desc: 'Is Green'
+            }, {
+                name: 'Pear',
+                color: 'Green'
+            }])
+        })
+
+        it('searches case-insensitively', () => {
+            const rows = [{
+                name: 'Apple',
+                desc: 'green'
+            }]
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: 'Green' }, rows)
+            ).toEqual([{
+                name: 'Apple',
+                desc: 'green'
+            }])
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: 'apple' }, rows)
+            ).toEqual([{
+                name: 'Apple',
+                desc: 'green'
+            }])
+        })
+
+        it('searches numbers as if they were strings', () => {
+            const rows = [{
+                number: '123'
+            },
+            {
+                number: 23
+            },
+            {
+                number: 12
+            }]
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: '23' }, rows)
+            ).toEqual([{
+                number: '123'
+            },
+            {
+                number: 23
+            }])
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: '12' }, rows)
+            ).toEqual([{
+                number: '123'
+            },
+            {
+                number: 12
+            }])
+        })
+
+        describe('with searchFields prop set', () => {
+            it('only searches matching properties', () => {
+                const rows = [{
+                    name: 'Apple',
+                    desc: 'Is Green'
+                }, {
+                    name: 'Banana',
+                    desc: 'Not as good as an Apple'
+                }, {
+                    name: 'Pear',
+                    color: 'Green'
+                }]
+
+                expect(
+                    DataTable.methods.filterRows.call({ internalSearch: 'Green', searchFields: ['desc'] }, rows)
+                ).toEqual([{
+                    name: 'Apple',
+                    desc: 'Is Green'
+                }])
+
+                expect(
+                    DataTable.methods.filterRows.call({ internalSearch: 'Green', searchFields: ['desc', 'color'] }, rows)
+                ).toEqual([{
+                    name: 'Apple',
+                    desc: 'Is Green'
+                },
+                {
+                    name: 'Pear',
+                    color: 'Green'
+                }])
+            })
+        })
+    })
+
     describe('filteredRows', () => {
         it('Sorts numbers descending', () => {
             const localThis = {


### PR DESCRIPTION
Fixes #35 by:

- Adding recursive search of objects by default
  e.g. `{ rows: [{ name: 'Device 1', project: { name: 'Project 1' ]` matches both `Device` and `Project`
- Adding support to `:search-fields` for nested properties 
  e.g. `['project.name']` for the above to match only the project name field
  
I intend to refactor the filtering and sorting logic out of the data-table into a service/helper in a follow-up if there's time. This would have two key advantages:

- Increase (and simplify) testability by decoupling it from data-tables and Vue
- Opens the possibility for supporting different approaches (.e.g server side)

This PR is likely easier to review commit by commit.