### PR TITLE
Restore sorting icons opacity

### DIFF
--- a/src/components/Check.vue
+++ b/src/components/Check.vue
@@ -1,6 +1,6 @@
 <template>
-    <i class="ff-icon-lg">
-        <CheckIcon v-if="value" class="ff-icon-lg" />
+    <i class="ff-icon ff-icon-lg">
+        <CheckIcon v-if="value" class="ff-icon ff-icon-lg" />
     </i>
 </template>
 

--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -24,9 +24,9 @@
                                 <!-- Internal div required to have flex w/sorting icons -->
                                 <div>
                                     {{ col.label }}
-                                    <SwitchVerticalIcon class="ff-icon-sm" v-if="col.sortable && col.key !== sort.key" />
-                                    <SortAscendingIcon class="ff-icon-sm icon-sorted" v-if="col.sortable && col.key === sort.key && sort.order === 'asc'" />
-                                    <SortDescendingIcon class="ff-icon-sm icon-sorted" v-if="col.sortable && col.key === sort.key && sort.order === 'desc'" />
+                                    <SwitchVerticalIcon class="ff-icon ff-icon-sm" v-if="col.sortable && col.key !== sort.key" />
+                                    <SortAscendingIcon class="ff-icon ff-icon-sm icon-sorted" v-if="col.sortable && col.key === sort.key && sort.order === 'asc'" />
+                                    <SortDescendingIcon class="ff-icon ff-icon-sm icon-sorted" v-if="col.sortable && col.key === sort.key && sort.order === 'desc'" />
                                 </div>
                             </ff-data-table-cell>
                             <ff-data-table-cell v-if="hasContextMenu"></ff-data-table-cell>

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -558,20 +558,20 @@ li.ff-list-item {
             justify-content: space-between;
             gap: $ff-unit-md;
           }
-          .ff-icon, .ff-icon-sm, .ff-icon-lg {
+          .ff-icon {
             opacity: 0.2;
           }
           &:hover {
             background-color: $ff-grey-200;
             cursor: pointer;
-            .ff-icon, .ff-icon-sm, .ff-icon-lg {
+            .ff-icon {
               opacity: 0.5;
             }
           }
         }
         &.sorted {
           background-color: $ff-grey-200;
-          .ff-icon.icon-sorted, .ff-icon-sm.icon-sorted, .ff-icon-lg.icon-sorted {
+          .ff-icon.icon-sorted {
             opacity: 1;
           }
         }

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -558,20 +558,20 @@ li.ff-list-item {
             justify-content: space-between;
             gap: $ff-unit-md;
           }
-          .ff-icon {
+          .ff-icon, .ff-icon-sm, .ff-icon-lg {
             opacity: 0.2;
           }
           &:hover {
             background-color: $ff-grey-200;
             cursor: pointer;
-            .ff-icon {
+            .ff-icon, .ff-icon-sm, .ff-icon-lg {
               opacity: 0.5;
             }
           }
         }
         &.sorted {
           background-color: $ff-grey-200;
-          .ff-icon.icon-sorted {
+          .ff-icon.icon-sorted, .ff-icon-sm.icon-sorted, .ff-icon-lg.icon-sorted {
             opacity: 1;
           }
         }


### PR DESCRIPTION
Fixes style issue with the sorting icons introduced in #81. Closes #39 

### Before

<img width="933" alt="Screenshot 2022-10-25 at 14 52 08" src="https://user-images.githubusercontent.com/507155/197778078-49496bed-3f35-438b-859e-e31402482af0.png">

### After

<img width="933" alt="Screenshot 2022-10-25 at 14 51 44" src="https://user-images.githubusercontent.com/507155/197778087-404b9654-3968-43c7-8e09-f42ae7c3f481.png">
