### PR TITLE
Handle `null` during data-table search

### DIFF
--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -70,7 +70,7 @@
 import { SearchIcon, SwitchVerticalIcon, SortAscendingIcon, SortDescendingIcon } from '@heroicons/vue/outline'
 
 function searchObjectProps (object, searchTerm, searchProps = []) {
-    const searchPropsMap = searchProps
+    const searchPropsMap = (searchProps ?? [])
         .map((prop) => {
             const [first, ...rest] = prop.split('.')
 

--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -70,7 +70,7 @@
 import { SearchIcon, SwitchVerticalIcon, SortAscendingIcon, SortDescendingIcon } from '@heroicons/vue/outline'
 
 function searchObjectProps (object, searchTerm, searchProps = []) {
-    const searchPropsMap = (searchProps ?? [])
+    const searchPropsMap = searchProps
         .map((prop) => {
             const [first, ...rest] = prop.split('.')
 

--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -92,6 +92,11 @@ function searchObjectProps (object, searchTerm, searchProps = []) {
             return false
         }
 
+        // Skip null, undefined, or empty props (inc arrays) since they'll never match
+        if (propValue === null || propValue === undefined || propValue.length === 0) {
+            return false
+        }
+
         // Search recursively inside of objects
         if (typeof propValue === 'object') {
             return searchObjectProps(propValue, searchTerm, searchPropsMap.get(propName))

--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="ff-data-table">
         <div v-if="showOptions" class="ff-data-table--options">
-            <ff-text-input v-if="showSearch" class="ff-data-table--search"
+            <ff-text-input v-if="showSearch" class="ff-data-table--search" data-form="search"
                 :placeholder="searchPlaceholder" v-model="filterTerm"
             >
                 <template #icon><SearchIcon /></template>

--- a/src/components/data-table/DataTable.vue
+++ b/src/components/data-table/DataTable.vue
@@ -120,11 +120,11 @@ export default {
     props: {
         columns: {
             type: Array,
-            default: null
+            default: () => []
         },
         rows: {
             type: Array,
-            default: null
+            default: () => []
         },
         rowsSelectable: {
             type: Boolean,
@@ -144,7 +144,7 @@ export default {
         },
         searchFields: {
             type: Array,
-            default: null
+            default: () => []
         },
         showLoadMore: {
             type: Boolean,

--- a/tests/unit/data-table/DataTable.spec.js
+++ b/tests/unit/data-table/DataTable.spec.js
@@ -114,6 +114,79 @@ describe('DataTable', () => {
             ).toEqual('Banana')
         })
 
+        it('searches (nested) arrays', () => {
+            const rows = [{
+                name: 'Apple',
+                colors: ['green', 'red']
+            }, {
+                name: 'Banana',
+                details: {
+                    colors: [{ name: 'yellow' }]
+                }
+            }]
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: 'green' }, rows).map((row) => row.name)
+            ).toEqual(['Apple'])
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: 'yellow' }, rows).map((row) => row.name)
+            ).toEqual(['Banana'])
+        })
+
+        it('handles searchFields prop being explicitly null, undefined or empty', () => {
+            const rows = [{
+                name: 'Apple',
+                desc: 'Is Green'
+            }, {
+                name: 'Banana',
+                desc: 'Not as good as an Apple'
+            }, {
+                name: 'Pear',
+                color: 'Green'
+            }]
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: 'green', searchFields: null }, rows).map((row) => row.name)
+            ).toEqual(['Apple', 'Pear'])
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: 'green', searchFields: undefined }, rows).map((row) => row.name)
+            ).toEqual(['Apple', 'Pear'])
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: 'green', searchFields: [] }, rows).map((row) => row.name)
+            ).toEqual(['Apple', 'Pear'])
+        })
+
+        it('handles prop values being being explicitly null, undefined or empty', () => {
+            const rows = [{
+                name: 'Apple',
+                meta: null
+            }, {
+                name: 'Banana',
+                meta: undefined
+            }, {
+                name: 'Pear',
+                meta: []
+            }, {
+                name: 'Orange',
+                meta: ''
+            }]
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: 'pear' }, rows).map((row) => row.name)
+            ).toEqual(['Pear'])
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: 'pear' }, rows).map((row) => row.name)
+            ).toEqual(['Pear'])
+
+            expect(
+                DataTable.methods.filterRows.call({ internalSearch: 'pear' }, rows).map((row) => row.name)
+            ).toEqual(['Pear'])
+        })
+
         describe('with searchFields prop set', () => {
             it('only searches matching properties', () => {
                 const rows = [{

--- a/tests/unit/data-table/DataTable.spec.js
+++ b/tests/unit/data-table/DataTable.spec.js
@@ -175,12 +175,12 @@ describe('DataTable', () => {
             }]
 
             expect(
-                DataTable.methods.filterRows.call({ internalSearch: 'pear' }, rows).map((row) => row.name)
-            ).toEqual(['Pear'])
+                DataTable.methods.filterRows.call({ internalSearch: 'apple' }, rows).map((row) => row.name)
+            ).toEqual(['Apple'])
 
             expect(
-                DataTable.methods.filterRows.call({ internalSearch: 'pear' }, rows).map((row) => row.name)
-            ).toEqual(['Pear'])
+                DataTable.methods.filterRows.call({ internalSearch: 'banana' }, rows).map((row) => row.name)
+            ).toEqual(['Banana'])
 
             expect(
                 DataTable.methods.filterRows.call({ internalSearch: 'pear' }, rows).map((row) => row.name)

--- a/tests/unit/data-table/DataTable.spec.js
+++ b/tests/unit/data-table/DataTable.spec.js
@@ -1,4 +1,70 @@
+import { mount } from '@vue/test-utils'
 import DataTable from '@/components/data-table/DataTable.vue'
+
+import FfDataTableRow from '@/components/data-table/DataTableRow.vue'
+import FfDataTableCell from '@/components/data-table/DataTableCell.vue'
+import FfKebabMenu from '@/components/KebabMenu.vue'
+import FfTextInput from '@/components/form/TextInput.vue'
+import FfCheck from '@/components/Check.vue'
+
+describe('DataTable UX', () => {
+    it('supports searching rows by values', async () => {
+        const wrapper = mount(DataTable, {
+            props: {
+                columns: [{
+                    key: 'name',
+                    label: 'Name'
+                }],
+                rows: [
+                    { name: 'Apple' },
+                    { name: 'Orange', details: null },
+                    { name: 'Grapefruit', details: { color: 'Orangey' } }
+                ],
+                showSearch: true
+            },
+            global: {
+                components: {
+                    FfDataTableRow, FfDataTableCell, FfTextInput, FfCheck, FfKebabMenu
+                }
+            }
+        })
+
+        expect(wrapper.find('tbody').text()).toBe('AppleOrangeGrapefruit')
+
+        await wrapper.find('[data-form="search"] input').setValue('Orange')
+
+        expect(wrapper.find('tbody').text()).toBe('OrangeGrapefruit')
+    })
+
+    it('supports searching rows by values in specific fields only', async () => {
+        const wrapper = mount(DataTable, {
+            props: {
+                columns: [{
+                    key: 'name',
+                    label: 'Name'
+                }],
+                rows: [
+                    { name: 'Apple' },
+                    { name: 'Orange' },
+                    { name: 'Grapefruit', details: { color: 'Orangey' } }
+                ],
+                showSearch: true,
+                searchFields: ['name']
+            },
+            global: {
+                components: {
+                    FfDataTableRow, FfDataTableCell, FfTextInput, FfCheck, FfKebabMenu
+                }
+            }
+        })
+
+        expect(wrapper.find('tbody').text()).toBe('AppleOrangeGrapefruit')
+
+        await wrapper.find('[data-form="search"] input').setValue('Orange')
+
+        expect(wrapper.find('tbody').text()).toBe('Orange')
+    })
+})
 
 describe('DataTable', () => {
     describe('filterRows', () => {

--- a/tests/unit/data-table/DataTable.spec.js
+++ b/tests/unit/data-table/DataTable.spec.js
@@ -134,7 +134,7 @@ describe('DataTable', () => {
             ).toEqual(['Banana'])
         })
 
-        it('handles searchFields prop being explicitly null, undefined or empty', () => {
+        it('handles searchFields prop being empty or undefined', () => {
             const rows = [{
                 name: 'Apple',
                 desc: 'Is Green'
@@ -145,10 +145,6 @@ describe('DataTable', () => {
                 name: 'Pear',
                 color: 'Green'
             }]
-
-            expect(
-                DataTable.methods.filterRows.call({ internalSearch: 'green', searchFields: null }, rows).map((row) => row.name)
-            ).toEqual(['Apple', 'Pear'])
 
             expect(
                 DataTable.methods.filterRows.call({ internalSearch: 'green', searchFields: undefined }, rows).map((row) => row.name)


### PR DESCRIPTION
Addresses two bugs introduced in https://github.com/flowforge/forge-ui-components/pull/85

- An row containing a `null` property would throw, as `null` is an object but `Object.entries()` does not support null
- `searchFields` prop defaulted to `null` but it was assumed to be an array

This also introduces the first fully mounted component test. The test simulates **user** rather than programatic interaction with this component, and represents the real world use case better. The majority of the existing unit tests calling the components methods and computed properties directly, will become the responsibility of the search/filter service when this is introduced (see description in #85).