### PR TITLE
Override input fields default minimum width

### DIFF
--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -222,6 +222,7 @@ li.ff-list-item {
       background: none;
       height: 100%;
       border-width: 0;
+      min-width: 0;
       &:focus-visible {
         border: none;
         outline: none;


### PR DESCRIPTION
Flex-Shrink doesn't work with text inputs by default as they have a minimum width set by browsers. Overriding it, allows it to shrink as expected.

This shouldn't cause any visual differences unless the parent element is smaller than the default width (about 100px)

Fixes https://github.com/flowforge/flowforge/issues/1161