### PR TITLE
Tile selection race condition

### DIFF
--- a/src/components/form/TileSelection.vue
+++ b/src/components/form/TileSelection.vue
@@ -18,9 +18,6 @@ export default {
     watch: {
         modelValue: function (value) {
             this.$nextTick(() => {
-                console.log('watch model value')
-                console.log(value)
-                console.log(this.children.length)
                 this.checkState(value)
             })
         }
@@ -55,7 +52,6 @@ export default {
     },
     mounted () {
         this.$nextTick(() => {
-            console.log('mounted')
             for (let i = 0; i < this.children.length; i++) {
                 if (this.modelValue !== this.children[i].value) {
                     this.children[i].selected = false

--- a/src/components/form/TileSelection.vue
+++ b/src/components/form/TileSelection.vue
@@ -18,13 +18,10 @@ export default {
     watch: {
         modelValue: function (value) {
             this.$nextTick(() => {
-                for (let i = 0; i < this.children.length; i++) {
-                    if (value !== this.children[i].value) {
-                        this.children[i].selected = false
-                    } else {
-                        this.children[i].selected = true
-                    }
-                }
+                console.log('watch model value')
+                console.log(value)
+                console.log(this.children.length)
+                this.checkState(value)
             })
         }
     },
@@ -37,6 +34,7 @@ export default {
     methods: {
         registerOption: function (child) {
             this.children.push(child)
+            this.checkState(this.modelValue)
         },
         setSelected (selected) {
             if (selected?.value === this.modelValue) {
@@ -44,10 +42,20 @@ export default {
             } else {
                 this.$emit('update:modelValue', selected.value)
             }
+        },
+        checkState (value) {
+            for (let i = 0; i < this.children.length; i++) {
+                if (value !== this.children[i].value) {
+                    this.children[i].selected = false
+                } else {
+                    this.children[i].selected = true
+                }
+            }
         }
     },
     mounted () {
         this.$nextTick(() => {
+            console.log('mounted')
             for (let i = 0; i < this.children.length; i++) {
                 if (this.modelValue !== this.children[i].value) {
                     this.children[i].selected = false

--- a/src/components/form/TileSelection.vue
+++ b/src/components/form/TileSelection.vue
@@ -42,11 +42,7 @@ export default {
         },
         checkState (value) {
             for (let i = 0; i < this.children.length; i++) {
-                if (value !== this.children[i].value) {
-                    this.children[i].selected = false
-                } else {
-                    this.children[i].selected = true
-                }
+                this.children[i].selected = value === this.children[i].value
             }
         }
     },

--- a/tests/unit/form/TileSelection.spec.js
+++ b/tests/unit/form/TileSelection.spec.js
@@ -1,0 +1,102 @@
+import { mount } from '@vue/test-utils'
+
+import TileSelection from '@/components/form/TileSelection.vue'
+import TileSelectionOption from '@/components/form/TileSelectionOption.vue'
+
+describe('Form > Tile Selection', () => {
+    it('should have no children by default', async () => {
+        const parent = mount(TileSelection, {
+            props: {
+                modelValue: null
+            },
+            global: {
+                components: {
+                    TileSelectionOption
+                }
+            }
+        })
+
+        expect(parent.findAllComponents('.ff-tile-selection-option').length).toBe(0)
+        expect(parent.vm.children.length).toBe(0)
+    })
+    it('should track registered children', async () => {
+        const mockCheckState = jest.spyOn(TileSelection.methods, 'checkState')
+        const parent = mount(TileSelection, {
+            props: {
+                modelValue: null
+            },
+            global: {
+                components: {
+                    TileSelectionOption
+                }
+            }
+        })
+
+        parent.vm.registerOption({})
+        expect(parent.vm.children.length).toBe(1)
+        expect(mockCheckState).toHaveBeenCalled()
+    })
+    it('emit updates to the model value - equal to the provided value if different to the existing value', async () => {
+        const tile = mount(TileSelection, {
+            props: {
+                modelValue: null
+            },
+            global: {
+                components: {
+                    TileSelectionOption
+                }
+            }
+        })
+
+        const selected = { value: 1 }
+
+        tile.vm.setSelected(selected)
+        await tile.vm.$nextTick()
+        expect(tile.emitted()['update:modelValue']).toBeTruthy()
+        expect(tile.emitted()['update:modelValue'][0]).toEqual([1])
+    })
+    it('emit updates to the model value - equal to null if different to the existing value', async () => {
+        const tile = mount(TileSelection, {
+            props: {
+                modelValue: null
+            },
+            global: {
+                components: {
+                    TileSelectionOption
+                }
+            }
+        })
+
+        const selected = { value: 1 }
+
+        // set the model value to 1
+        await tile.setProps({ modelValue: 1 })
+        // run the "select" function, to assign to existing value
+        tile.vm.setSelected(selected)
+        await tile.vm.$nextTick()
+        // the emission should have occured
+        expect(tile.emitted()['update:modelValue']).toBeTruthy()
+        expect(tile.emitted()['update:modelValue'][0]).toEqual([null])
+    })
+    it('should update the child "selected" state depending on the controllers model value', async () => {
+        const tile = mount(TileSelection, {
+            props: {
+                modelValue: null
+            },
+            global: {
+                components: {
+                    TileSelectionOption
+                }
+            }
+        })
+
+        await tile.setData({ children: [{ value: 1, selected: false }, { value: 2, selected: false }] })
+
+        tile.vm.checkState(2)
+        await tile.vm.$nextTick()
+        // the emission should have occured
+        expect(tile.vm.children.length).toBe(2)
+        expect(tile.vm.children[0].selected).toBeFalsy()
+        expect(tile.vm.children[1].selected).toBeTruthy()
+    })
+})


### PR DESCRIPTION
If a value is set on the `tile-selection` _before_ the relevant child element has been added, then the `tile-selection-option` does not have it's `selected` state set correctly. This change makes sure that, upon a new child element being added to the options, we check the `modelValue` to see if the `selected` state needs to be set to true/false on that child.