### PR TITLE
Improve Radio Group layout & styling

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -382,8 +382,15 @@
                 <h3>Examples:</h3>
                 <div class="examples">
                     <div class="example">
+                        <h5>Example 1: Default</h5>
                         <ff-checkbox label="My Checkbox" v-model="models.checkbox0"></ff-checkbox>
                         {{ models.checkbox0 }}
+                        <code>{{ cGroups['input'].components[2].examples[0].code }}</code>
+                    </div>
+                    <div class="example">
+                        <h5>Example 2: Disabled</h5>
+                        <ff-checkbox label="My Checkbox" v-model="models.checkbox1" :disabled="true"></ff-checkbox>
+                        {{ models.checkbox1 }}
                         <code>{{ cGroups['input'].components[2].examples[0].code }}</code>
                     </div>
                 </div>
@@ -407,7 +414,7 @@
                     </div>
                     <div class="example">
                         <h5>Example 3: Disabled Option</h5>
-                        <ff-radio-group v-model="models.radio1" label="We can also provide a label here" :options="[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Disabled Option', value: 2, description: 'Another description', disabled: true}]" orientation="vertical"></ff-radio-group>
+                        <ff-radio-group v-model="models.radio2" label="We can also provide a label here" :options="[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Disabled Option', value: 2, description: 'Another description', disabled: true}]" orientation="vertical"></ff-radio-group>
                         {{ models.radio2 }}
                         <code>{{ cGroups['input'].components[3].examples[1].code }}</code>
                     </div>
@@ -637,6 +644,7 @@ export default {
                 dropdown0: null,
                 dropdown1: null,
                 checkbox0: false,
+                checkbox1: false,
                 radio0: null,
                 radio1: null,
                 radio2: null,

--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -394,13 +394,21 @@
                 <h3>Examples:</h3>
                 <div class="examples">
                     <div class="example">
+                        <h5>Example 1: Horizontal</h5>
                         <ff-radio-group v-model="models.radio0" :options="[{label: 'Option 1', value: 1, checked: true}, {label: 'Option 2', value: 2}]"></ff-radio-group>
                         {{ models.radio0 }}
                         <code>{{ cGroups['input'].components[3].examples[0].code }}</code>
                     </div>
                     <div class="example">
+                        <h5>Example 2: Vertical &amp; Descriptions</h5>
                         <ff-radio-group v-model="models.radio1" label="We can also provide a label here" :options="[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Option 2', value: 2, description: 'Another description'}]" orientation="vertical"></ff-radio-group>
                         {{ models.radio1 }}
+                        <code>{{ cGroups['input'].components[3].examples[1].code }}</code>
+                    </div>
+                    <div class="example">
+                        <h5>Example 3: Disabled Option</h5>
+                        <ff-radio-group v-model="models.radio1" label="We can also provide a label here" :options="[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Disabled Option', value: 2, description: 'Another description', disabled: true}]" orientation="vertical"></ff-radio-group>
+                        {{ models.radio2 }}
                         <code>{{ cGroups['input'].components[3].examples[1].code }}</code>
                     </div>
                 </div>
@@ -631,6 +639,7 @@ export default {
                 checkbox0: false,
                 radio0: null,
                 radio1: null,
+                radio2: null,
                 tiles0: null,
                 tiles1: null,
                 tiles3: 3

--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -388,7 +388,7 @@
                     </div>
                 </div>
                 <!-- Radio -->
-                <h2 ref="ff-radio-group"><pre>ff-radio</pre></h2>
+                <h2 ref="ff-radio-group"><pre>ff-radio-group</pre></h2>
                 <h3>Properties:</h3>
                 <props-table :rows="cGroups['input'].components[3].props"></props-table>
                 <h3>Examples:</h3>
@@ -399,7 +399,7 @@
                         <code>{{ cGroups['input'].components[3].examples[0].code }}</code>
                     </div>
                     <div class="example">
-                        <ff-radio-group v-model="models.radio1" label="We can also provide a label here" :options="[{label: 'Option 1', value: 1, checked: true}, {label: 'Option 2', value: 2}]" orientation="vertical"></ff-radio-group>
+                        <ff-radio-group v-model="models.radio1" label="We can also provide a label here" :options="[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Option 2', value: 2, description: 'Another description'}]" orientation="vertical"></ff-radio-group>
                         {{ models.radio1 }}
                         <code>{{ cGroups['input'].components[3].examples[1].code }}</code>
                     </div>

--- a/docs/data/input.docs.json
+++ b/docs/data/input.docs.json
@@ -80,7 +80,7 @@
         "examples": [{
             "code": "<ff-radio-group v-model=\"myVar\" :options=\"[{label: 'Option 1', value: 1, checked: true}, {label: 'Option 2', value: 2}]\"></ff-radio-group>"
         }, {
-            "code": "<ff-radio-group label=\"We can also provide a label here\" v-model=\"myVar\" orientation=\"vertical\" :options=\"[{label: 'Option 1', value: 1, checked: true}, {label: 'Option 2', value: 2}]\"></ff-radio-group>"
+            "code": "<ff-radio-group label=\"We can also provide a label here\" v-model=\"myVar\" orientation=\"vertical\" :options=\"[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Option 2', value: 2, description: 'Another description'}]\"></ff-radio-group>"
         }],
         "props": [{
             "key": "options",

--- a/src/components/form/Checkbox.vue
+++ b/src/components/form/Checkbox.vue
@@ -1,8 +1,8 @@
 <template>
-    <label class="ff-checkbox">
-        <input type="checkbox" :value="modelValue" v-model="model" />
+    <label class="ff-checkbox" :disabled="disabled">
+        <input type="checkbox" :value="modelValue" :disabled="disabled" v-model="model" />
         <span class="checkbox" :checked="model"></span>
-        <label @click="model = !model">
+        <label @click="toggle">
             <slot>{{ label }}</slot>
         </label>
     </label>
@@ -15,6 +15,10 @@ export default {
         label: {
             required: true,
             type: String
+        },
+        disabled: {
+            default: false,
+            type: Boolean
         },
         modelValue: {
             required: true,
@@ -29,6 +33,13 @@ export default {
             },
             set (value) {
                 this.$emit('update:modelValue', value)
+            }
+        }
+    },
+    methods: {
+        toggle () {
+            if (!this.disabled) {
+                this.model = !this.model
             }
         }
     }

--- a/src/components/form/RadioButton.vue
+++ b/src/components/form/RadioButton.vue
@@ -3,7 +3,7 @@
         <input type="radio" :value="value" />
         <span class="checkbox" :checked="checked"></span>
         <label>{{ label }}</label>
-        <p v-if="showDescription" class="ff-description">{{ description }}</p>
+        <p v-if="description && !hideDescription" class="ff-description">{{ description }}</p>
     </label>
 </template>
 
@@ -27,7 +27,7 @@ export default {
             default: null,
             type: String
         },
-        showDescription: {
+        hideDescription: {
             default: false,
             type: Boolean
         }

--- a/src/components/form/RadioButton.vue
+++ b/src/components/form/RadioButton.vue
@@ -3,6 +3,7 @@
         <input type="radio" :value="value" />
         <span class="checkbox" :checked="checked"></span>
         <label>{{ label }}</label>
+        <p v-if="showDescription" class="ff-description">{{ description }}</p>
     </label>
 </template>
 
@@ -19,6 +20,14 @@ export default {
             type: [String, Number]
         },
         checked: {
+            default: false,
+            type: Boolean
+        },
+        description: {
+            default: null,
+            type: String
+        },
+        showDescription: {
             default: false,
             type: Boolean
         }

--- a/src/components/form/RadioButton.vue
+++ b/src/components/form/RadioButton.vue
@@ -1,5 +1,5 @@
 <template>
-    <label class="ff-radio-btn" @click="select(value)">
+    <label class="ff-radio-btn" :disabled="disabled" @click="select(value)">
         <input type="radio" :value="value" />
         <span class="checkbox" :checked="checked"></span>
         <label>{{ label }}</label>
@@ -27,6 +27,10 @@ export default {
             default: null,
             type: String
         },
+        disabled: {
+            default: false,
+            type: Boolean
+        },
         hideDescription: {
             default: false,
             type: Boolean
@@ -35,7 +39,9 @@ export default {
     emits: ['select'],
     methods: {
         select: function (value) {
-            this.$emit('select', value)
+            if (!this.disabled) {
+                this.$emit('select', value)
+            }
         }
     }
 }

--- a/src/components/form/RadioGroup.vue
+++ b/src/components/form/RadioGroup.vue
@@ -4,7 +4,7 @@
         <ff-radio-button v-for="option in internalOptions" :key="option.label"
             :value="option.value" :label="option.label" :checked="option.checked"
             :description="option.description"
-            :show-description="(orientation === 'vertical' && option.description)"
+            :hide-description="orientation === 'horizontal'"
             @select="select"
         ></ff-radio-button>
     </div>

--- a/src/components/form/RadioGroup.vue
+++ b/src/components/form/RadioGroup.vue
@@ -3,6 +3,8 @@
         <label class="ff-radio-group-label" v-if="label">{{ label }}</label>
         <ff-radio-button v-for="option in internalOptions" :key="option.label"
             :value="option.value" :label="option.label" :checked="option.checked"
+            :description="option.description"
+            :show-description="(orientation === 'vertical' && option.description)"
             @select="select"
         ></ff-radio-button>
     </div>

--- a/src/components/form/RadioGroup.vue
+++ b/src/components/form/RadioGroup.vue
@@ -4,6 +4,7 @@
         <ff-radio-button v-for="option in internalOptions" :key="option.label"
             :value="option.value" :label="option.label" :checked="option.checked"
             :description="option.description"
+            :disabled="option.disabled"
             :hide-description="orientation === 'horizontal'"
             @select="select"
         ></ff-radio-button>

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -324,10 +324,19 @@ li.ff-list-item {
     background-color: transparent;
     border: 1px solid $ff-grey-400;    
   }
-  &:hover {
+  &:hover:not([disabled=true]) {
     .checkbox {
       background-color: $ff-grey-200;
     }
+  }
+  &[disabled=true] {
+    cursor: not-allowed;
+    label, p {
+      color: $ff-grey-400;
+    }
+  }
+  &[disabled=true] * {
+    pointer-events: none;
   }
   .checkbox {
     &[checked=true] {

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -309,7 +309,6 @@ li.ff-list-item {
   cursor: pointer;
   input[type=checkbox], input[type=radio] {
     display: none;
-    // background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e")
   }
   label {
     cursor: pointer;

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -308,7 +308,7 @@ li.ff-list-item {
   padding-left: 25px;
   cursor: pointer;
   input[type=checkbox], input[type=radio] {
-    display: none
+    display: none;
     // background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e")
   }
   label {
@@ -321,10 +321,27 @@ li.ff-list-item {
     left: 0;
     height: 16px;
     width: 16px;
-    border-radius: $ff-unit-xs;
+    border-radius: 4px;
     background-color: transparent;
     border: 1px solid $ff-grey-400;    
   }
+  &:hover {
+    .checkbox {
+      background-color: $ff-grey-200;
+    }
+  }
+  .checkbox {
+    &[checked=true] {
+      background-color: $ff-grey-600;
+      border-color: $ff-grey-700;
+    }
+    &[checked=true]:after {
+      display: block;
+    }
+  }
+}
+
+.ff-checkbox {
   .checkbox:after {
     content: "";
     display: none;
@@ -339,26 +356,12 @@ li.ff-list-item {
     -ms-transform: rotate(45deg);
     transform: rotate(45deg);
   }
-  &:hover {
-    .checkbox {
-      background-color: $ff-grey-200;
-    }
-  }
-  .checkbox {
-    &[checked=true] {
-      background-color: $ff-grey-800;
-      border-color: $ff-grey-900;
-    }
-    &[checked=true]:after {
-      display: block;
-    }
-  }
 }
 
 .ff-radio-group {
   .ff-radio-group-label {
     display: block;
-    margin-bottom: $ff-unit-md;
+    margin-bottom: 1rem;
   }
   &.ff-radio-group--horizontal {
     .ff-radio-btn {
@@ -380,22 +383,10 @@ li.ff-list-item {
     left: 0;
     height: 16px;
     width: 16px;
-    border-radius: 8px;
+    border-radius: 4px;
     background-color: transparent;
-    border: 1px solid $ff-grey-400;    
-  }
-  .checkbox:after {
-    content: "";
-    display: none;
-    position: absolute;
-    left: 0px;
-    top: 0px;
-    width: 14px;
-    height: 14px;
-    background-color: black;
-    border: solid white;
-    border-width: 2px;
-    border-radius: 50%;
+    border: 1px solid $ff-grey-400;
+    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e")    
   }
 }
 

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -306,12 +306,16 @@ li.ff-list-item {
 .ff-radio-btn {
   position: relative;
   padding-left: 25px;
+  display: flex;
   cursor: pointer;
   input[type=checkbox], input[type=radio] {
     display: none;
   }
   label {
     cursor: pointer;
+    font-weight: 500;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
   }
   /* Create a custom checkbox */
   .checkbox {
@@ -372,6 +376,7 @@ li.ff-list-item {
     margin-bottom: 1rem;
   }
   &.ff-radio-group--horizontal {
+    display: flex;
     .ff-radio-btn {
       margin-right: $ff-funit-lg;
     }

--- a/src/stylesheets/ff-core.scss
+++ b/src/stylesheets/ff-core.scss
@@ -56,5 +56,5 @@ p code {
 
 .ff-description {
     font-size: $ff-funit-sm;
-    color: $ff-grey-500;
+    color: $ff-grey-400;
 }

--- a/src/stylesheets/ff-core.scss
+++ b/src/stylesheets/ff-core.scss
@@ -53,3 +53,8 @@ code {
 p code {
     padding: 0 $ff-unit-xs;
 }
+
+.ff-description {
+    font-size: $ff-funit-sm;
+    color: $ff-grey-500;
+}

--- a/src/stylesheets/ff-theme-dark.scss
+++ b/src/stylesheets/ff-theme-dark.scss
@@ -19,6 +19,10 @@
         border-color: $ff-grey-700;
     }
 
+    .ff-description {
+        color: $ff-grey-400;
+    }
+
     /* FlowForge Components */
 
     .ff-btn {

--- a/src/stylesheets/ff-theme-light.scss
+++ b/src/stylesheets/ff-theme-light.scss
@@ -7,8 +7,13 @@
     h1, h2, h3, h4, h5{
         color: $ff-grey-700;
     }
+    
     p {
         color: $ff-grey-800;
+    }
+
+    .ff-description {
+        color: $ff-grey-500;
     }
 
     select {


### PR DESCRIPTION
As part of the FormRow revamp in core FlowForge I will be pushing through a few underlying component updates. Here, we add the option for each radio button to have its own description as per latest designs in Figma.

**Before**:


https://user-images.githubusercontent.com/99246719/200032075-20b70785-9492-4847-96e5-de153f228563.mov


**After:**

https://user-images.githubusercontent.com/99246719/200031818-738f4ea1-eedd-4bba-bcf9-e90607f8eb12.mov


