### PR TITLE
Move the component tests for data table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-node_modules
-/dist
+.DS_Store
+node_modules/
+/dist/
+
+# Log files
+npm-debug.log*

--- a/tests/component/data-table/DataTable.spec.js
+++ b/tests/component/data-table/DataTable.spec.js
@@ -7,7 +7,7 @@ import FfKebabMenu from '@/components/KebabMenu.vue'
 import FfTextInput from '@/components/form/TextInput.vue'
 import FfCheck from '@/components/Check.vue'
 
-describe('DataTable', () => {
+describe('Data-Table > DataTable', () => {
     it('supports searching rows by values', async () => {
         const wrapper = mount(DataTable, {
             props: {

--- a/tests/component/data-table/DataTable.spec.js
+++ b/tests/component/data-table/DataTable.spec.js
@@ -1,0 +1,67 @@
+import { mount } from '@vue/test-utils'
+import DataTable from '@/components/data-table/DataTable.vue'
+
+import FfDataTableRow from '@/components/data-table/DataTableRow.vue'
+import FfDataTableCell from '@/components/data-table/DataTableCell.vue'
+import FfKebabMenu from '@/components/KebabMenu.vue'
+import FfTextInput from '@/components/form/TextInput.vue'
+import FfCheck from '@/components/Check.vue'
+
+describe('DataTable', () => {
+    it('supports searching rows by values', async () => {
+        const wrapper = mount(DataTable, {
+            props: {
+                columns: [{
+                    key: 'name',
+                    label: 'Name'
+                }],
+                rows: [
+                    { name: 'Apple' },
+                    { name: 'Orange', details: null },
+                    { name: 'Grapefruit', details: { color: 'Orangey' } }
+                ],
+                showSearch: true
+            },
+            global: {
+                components: {
+                    FfDataTableRow, FfDataTableCell, FfTextInput, FfCheck, FfKebabMenu
+                }
+            }
+        })
+
+        expect(wrapper.find('tbody').text()).toBe('AppleOrangeGrapefruit')
+
+        await wrapper.find('[data-form="search"] input').setValue('Orange')
+
+        expect(wrapper.find('tbody').text()).toBe('OrangeGrapefruit')
+    })
+
+    it('supports searching rows by values in specific fields only', async () => {
+        const wrapper = mount(DataTable, {
+            props: {
+                columns: [{
+                    key: 'name',
+                    label: 'Name'
+                }],
+                rows: [
+                    { name: 'Apple' },
+                    { name: 'Orange' },
+                    { name: 'Grapefruit', details: { color: 'Orangey' } }
+                ],
+                showSearch: true,
+                searchFields: ['name']
+            },
+            global: {
+                components: {
+                    FfDataTableRow, FfDataTableCell, FfTextInput, FfCheck, FfKebabMenu
+                }
+            }
+        })
+
+        expect(wrapper.find('tbody').text()).toBe('AppleOrangeGrapefruit')
+
+        await wrapper.find('[data-form="search"] input').setValue('Orange')
+
+        expect(wrapper.find('tbody').text()).toBe('Orange')
+    })
+})

--- a/tests/unit/components/data-table/DataTable.spec.js
+++ b/tests/unit/components/data-table/DataTable.spec.js
@@ -1,6 +1,6 @@
 import DataTable from '@/components/data-table/DataTable.vue'
 
-describe('DataTable', () => {
+describe('Data-Table > DataTable', () => {
     describe('#filterRows', () => {
         it('searches all properties and returns matching subset of rows', () => {
             const rows = [{

--- a/tests/unit/components/form/TileSelection.spec.js
+++ b/tests/unit/components/form/TileSelection.spec.js
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils'
 import TileSelection from '@/components/form/TileSelection.vue'
 import TileSelectionOption from '@/components/form/TileSelectionOption.vue'
 
-describe('Form > Tile Selection', () => {
+describe('Form > TileSelection', () => {
     it('should have no children by default', async () => {
         const parent = mount(TileSelection, {
             props: {

--- a/tests/unit/data-table/DataTable.spec.js
+++ b/tests/unit/data-table/DataTable.spec.js
@@ -1,73 +1,7 @@
-import { mount } from '@vue/test-utils'
 import DataTable from '@/components/data-table/DataTable.vue'
 
-import FfDataTableRow from '@/components/data-table/DataTableRow.vue'
-import FfDataTableCell from '@/components/data-table/DataTableCell.vue'
-import FfKebabMenu from '@/components/KebabMenu.vue'
-import FfTextInput from '@/components/form/TextInput.vue'
-import FfCheck from '@/components/Check.vue'
-
-describe('DataTable UX', () => {
-    it('supports searching rows by values', async () => {
-        const wrapper = mount(DataTable, {
-            props: {
-                columns: [{
-                    key: 'name',
-                    label: 'Name'
-                }],
-                rows: [
-                    { name: 'Apple' },
-                    { name: 'Orange', details: null },
-                    { name: 'Grapefruit', details: { color: 'Orangey' } }
-                ],
-                showSearch: true
-            },
-            global: {
-                components: {
-                    FfDataTableRow, FfDataTableCell, FfTextInput, FfCheck, FfKebabMenu
-                }
-            }
-        })
-
-        expect(wrapper.find('tbody').text()).toBe('AppleOrangeGrapefruit')
-
-        await wrapper.find('[data-form="search"] input').setValue('Orange')
-
-        expect(wrapper.find('tbody').text()).toBe('OrangeGrapefruit')
-    })
-
-    it('supports searching rows by values in specific fields only', async () => {
-        const wrapper = mount(DataTable, {
-            props: {
-                columns: [{
-                    key: 'name',
-                    label: 'Name'
-                }],
-                rows: [
-                    { name: 'Apple' },
-                    { name: 'Orange' },
-                    { name: 'Grapefruit', details: { color: 'Orangey' } }
-                ],
-                showSearch: true,
-                searchFields: ['name']
-            },
-            global: {
-                components: {
-                    FfDataTableRow, FfDataTableCell, FfTextInput, FfCheck, FfKebabMenu
-                }
-            }
-        })
-
-        expect(wrapper.find('tbody').text()).toBe('AppleOrangeGrapefruit')
-
-        await wrapper.find('[data-form="search"] input').setValue('Orange')
-
-        expect(wrapper.find('tbody').text()).toBe('Orange')
-    })
-})
-
 describe('DataTable', () => {
-    describe('filterRows', () => {
+    describe('#filterRows', () => {
         it('searches all properties and returns matching subset of rows', () => {
             const rows = [{
                 name: 'Apple',
@@ -409,7 +343,7 @@ describe('DataTable', () => {
         })
     })
 
-    describe('filteredRows', () => {
+    describe('#filteredRows', () => {
         it('Sorts numbers descending', () => {
             const localThis = {
                 lookupProperty: DataTable.methods.lookupProperty,


### PR DESCRIPTION
As per discussion at team day, this splits our ui-components tests to follow the Vue.js conventions of:

 - Unit tests - a subset of a component - aware of the implementation details - uses mocking, stubbing, etc
 - Component tests - unaware of implementation details - does not touch private state - only interaction is via "user"

The component tests should be happy path coverage of the component, while the unit tests should be covering any edge cases. Long term, all the UI components should have their own component tests, but only some will need unit tests.
