### PR TITLE
Tooltip & Data Table CSS fixes

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -622,22 +622,22 @@
                 <div class="examples">
                     <div class="example">
                         <h5>Example 1: Default</h5>
-                        <div v-ff-tooltip="'Hello World'">Hover for Default Tooltip</div>
+                        <label v-ff-tooltip="'Hello World'">Hover for Default Tooltip</label>
                         <code>{{ dGroups['tooltip'].components[0].examples[0].code }}</code>
                     </div>
                     <div class="example">
                         <h5>Example 2: Left</h5>
-                        <div v-ff-tooltip:left="'Hello World'">Hover for Left Tooltip</div>
+                        <ff-check v-ff-tooltip:left="'Hello World'" :value="true"></ff-check>
                         <code>{{ dGroups['tooltip'].components[0].examples[1].code }}</code>
                     </div>
                     <div class="example">
                         <h5>Example 3: Top</h5>
-                        <div v-ff-tooltip:top="'Hello World'">Hover for Top Tooltip</div>
+                        <ff-button v-ff-tooltip:top="'Hello World'">Hover for Top Tooltip</ff-button>
                         <code>{{ dGroups['tooltip'].components[0].examples[2].code }}</code>
                     </div>
                     <div class="example">
                         <h5>Example 4: Bottom</h5>
-                        <div v-ff-tooltip:bottom="'Hello World'">Hover for Bottom Tooltip</div>
+                        <ff-notification-pill v-ff-tooltip:bottom="'Hello World'" :count="4">Hover for Bottom Tooltip</ff-notification-pill>
                         <code>{{ dGroups['tooltip'].components[0].examples[3].code }}</code>
                     </div>
                 </div>

--- a/docs/data/tooltip.docs.json
+++ b/docs/data/tooltip.docs.json
@@ -7,11 +7,11 @@
         "examples": [{
             "code": "<div v-ff-tooltip=\"'Hello World'\">Hover for Default Tooltip</div>"
         }, {
-            "code": "<div v-ff-tooltip:left=\"'Hello World'\">Hover for Left Tooltip</div>"
+            "code": "<ff-check v-ff-tooltip:left=\"'Hello World'\" :value=\"true\">Hover for Left Tooltip</ff-check>"
         }, {
-            "code": "<div v-ff-tooltip:top=\"'Hello World'\">Hover for Top Tooltip</div>"
+            "code": "<ff-button v-ff-tooltip:top=\"'Hello World'\">Hover for Top Tooltip</ff-button>"
         }, {
-            "code": "<div v-ff-tooltip:bottom=\"'Hello World'\">Hover for Bottom Tooltip</div>"
+            "code": "<ff-notification-pill v-ff-tooltip:bottom=\"'Hello World'\" :count=\"4\">Hover for Bottom Tooltip</ff-notification-pill>"
         }],
         "props": [{
             "key": "position",

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -573,10 +573,10 @@ li.ff-list-item {
     thead {
       .ff-data-table--row .ff-data-table--cell {
         &:first-child {
-          border-top-left-radius: 4px;
+          border-top-left-radius: 6px;
         }
         &:last-child {
-          border-top-right-radius: 4px;
+          border-top-right-radius: 6px;
         }
       }
       .ff-data-table--cell {
@@ -616,10 +616,10 @@ li.ff-list-item {
           border-bottom-width: 1px;
           border-top-color: $ff-grey-200;
           &:first-child {
-            border-bottom-left-radius: 4px;
+            border-bottom-left-radius: 6px;
           }
           &:last-child {
-            border-bottom-right-radius: 4px;
+            border-bottom-right-radius: 6px;
           }
         }
       }
@@ -991,7 +991,6 @@ $countdown_size: 20px;
 }
 .ff-tooltip-container {
   position: relative;
-  display: inline-block;
   &:hover .ff-tooltip {
     opacity: 1;
   }


### PR DESCRIPTION
- Remove opinionated `display: inline-block` of tooltip-container
- Include more varied examples in doc for tooltip usage
- Cleaner data-table border-radius (consistent with other radii in UI)