### PR TITLE
Add ff-help-tooltip

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -338,6 +338,27 @@
                 </div>
             </div>
             <div class="section">
+                <!-- Help Tooltip -->
+                <h1>Help Tooltip</h1>
+                <!-- Help Tooltip -->
+                <h2 ref="ff-help"><pre>ff-help-tooltip</pre></h2>
+                <h3>Properties:</h3>
+                <props-table :rows="cGroups['help'].components[0].props"></props-table>
+                <h3>Examples:</h3>
+                <div class="examples">
+                    <div class="example">
+                        <h5>Default Position</h5>
+                        <h5>Sample Header<ff-help text="Hello World"></ff-help></h5>
+                        <code>{{ cGroups['help'].components[0].examples[0].code }}</code>
+                    </div>
+                    <div class="example">
+                        <h5>Alternative Position</h5>
+                        <ff-help text="Hello World" position="bottom"></ff-help>
+                        <code>{{ cGroups['help'].components[0].examples[1].code }}</code>
+                    </div>
+                </div>
+            </div>
+            <div class="section">
                 <!-- Form Elements -->
                 <h1>Form Elements</h1>
                 <!-- Text Input -->
@@ -658,6 +679,7 @@ import SlotsTable from './components/SlotsTable.vue'
 import buttonDocs from './data/button.docs.json'
 import tableDocs from './data/table.docs.json'
 import dialogDocs from './data/dialog.docs.json'
+import helpDocs from './data/help.docs.json'
 import inputDocs from './data/input.docs.json'
 import notificationsDocs from './data/notifications.docs.json'
 import tabsDocs from './data/tabs.docs.json'
@@ -708,6 +730,7 @@ export default {
                 button: buttonDocs,
                 'data-table': tableDocs,
                 dialog: dialogDocs,
+                help: helpDocs,
                 input: inputDocs,
                 notifications: notificationsDocs,
                 tabs: tabsDocs,

--- a/docs/data/help.docs.json
+++ b/docs/data/help.docs.json
@@ -10,12 +10,11 @@
         }],
         "props": [{
             "key": "text",
-            "default": "Dialog Box",
-            "description": "<string> to display in the main header bar of the dialog box"
+            "description": "<string> to display in the attached tooltip"
         }, {
             "key": "position",
-            "default": "Confirm",
-            "description": "The text contained within the primary button of the dialog box."
+            "default": "right",
+            "description": "<string> Any of the positioning options available in the ff-tooltip directive. Positions the tooltip with respect to the help icon."
         }]
     }]
 }

--- a/docs/data/help.docs.json
+++ b/docs/data/help.docs.json
@@ -1,0 +1,21 @@
+{
+    "name": "Help Tooltip",
+    "id": "help-tooltip",
+    "components": [{
+        "name": "ff-help",
+        "examples": [{
+            "code": "<h5>Sample Header<ff-help text=\"Hello World\"></ff-help></h5>"
+        }, {
+            "code": "<ff-help text=\"Hello World\" position=\"bottom\"></ff-help>"
+        }],
+        "props": [{
+            "key": "text",
+            "default": "Dialog Box",
+            "description": "<string> to display in the main header bar of the dialog box"
+        }, {
+            "key": "position",
+            "default": "Confirm",
+            "description": "The text contained within the primary button of the dialog box."
+        }]
+    }]
+}

--- a/src/components.js
+++ b/src/components.js
@@ -8,6 +8,8 @@ import FFDataTableCell from './components/data-table/DataTableCell.vue'
 
 import FFDialogBox from './components/DialogBox.vue'
 
+import FFHelpTooltip from './components/Help.vue'
+
 // Form Elements
 import FFTextInput from './components/form/TextInput.vue'
 import FFDropdown from './components/form/Dropdown.vue'
@@ -35,6 +37,7 @@ export default {
     FFButton,
     FFKebabMenu,
     FFDialogBox,
+    FFHelpTooltip,
     FFListItem,
     FFCheck,
     FFMarkdownViewer,

--- a/src/components/Help.vue
+++ b/src/components/Help.vue
@@ -1,0 +1,27 @@
+<template>
+    <span class="ff-help-tooltip ff-icon" v-ff-tooltip:[position]="text">
+        <QuestionMarkCircleIcon />
+    </span>
+</template>
+
+<script>
+
+import { QuestionMarkCircleIcon } from '@heroicons/vue/solid'
+
+export default {
+    name: 'ff-help',
+    props: {
+        text: {
+            required: true,
+            type: String
+        },
+        position: {
+            default: 'right',
+            type: String
+        }
+    },
+    components: {
+        QuestionMarkCircleIcon
+    }
+}
+</script>

--- a/src/directives/Tooltip.js
+++ b/src/directives/Tooltip.js
@@ -1,6 +1,7 @@
 const directive = {
     name: 'ff-tooltip',
     mounted: (el, binding) => {
+        console.log(el, binding)
         if (el && binding) {
             el.classList.add('ff-tooltip-container')
             let posClass = 'ff-tooltip-right'

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -738,6 +738,18 @@ li.ff-list-item {
 }
 
 /*
+  Help Tooltip
+*/
+
+.ff-help-tooltip {
+  &:hover {
+    path {
+      fill: $ff-blue-800;
+    }
+  }
+}
+
+/*
   Notifications
 */
 
@@ -921,6 +933,7 @@ $countdown_size: 20px;
 .ff-tooltip {
   position: absolute;
   z-index: 100;
+  font-weight: normal; // prevent parent overriding if embedded in hX
   white-space: nowrap;
   background-color: black;
   color: white;
@@ -991,6 +1004,7 @@ $countdown_size: 20px;
 }
 .ff-tooltip-container {
   position: relative;
+  vertical-align: bottom;
   &:hover .ff-tooltip {
     opacity: 1;
   }


### PR DESCRIPTION
Part of work in #27. Will provide an easy-to-use help tooltip (uses our `v-ff-tooltip` directive under the covers, anywhere in FlowForge.

<img width="1315" alt="Screenshot 2022-11-23 at 14 06 42" src="https://user-images.githubusercontent.com/99246719/203566959-20740ba7-7ca2-448e-9d97-2ee81ca565ba.png">
