### PR TITLE
Re-work dialogs to scroll outside the modal

### DIFF
--- a/src/components/DialogBox.vue
+++ b/src/components/DialogBox.vue
@@ -12,8 +12,6 @@
                 </slot>
             </div>
         </div>
-        <div class="ff-dialog-backdrop">
-        </div>
     </div>
 </template>
 

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -685,7 +685,9 @@ li.ff-list-item {
   width: 100%;
   height: 100%;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
+  overflow-y: auto;
+  background-color: rgba($ff-grey-800, 0.3);
   &--open {
     display: flex;
   }
@@ -699,8 +701,7 @@ li.ff-list-item {
   z-index: 2;
   width: 100%;
   max-width: 42rem;
-  margin-top: 60px;
-  max-height: calc(100% - 84px);
+  margin: 90px auto;
   display: flex;
   flex-direction: column;
   background-color: $ff-white;
@@ -716,7 +717,7 @@ li.ff-list-item {
     }
     &-content {
       padding: $ff-funit-lg;
-      overflow-y: auto;
+      overflow-y: visible;
     }
     &-actions {
       display: flex;
@@ -727,14 +728,6 @@ li.ff-list-item {
       }
     }
   }
-}
-
-.ff-dialog-backdrop {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-color: $ff-grey-800;
-  opacity: 0.3;
 }
 
 /*


### PR DESCRIPTION
After running out of time-boxed time to fix #105 (and indirectly #107) by redesigning the tooltips and dropdowns, after some discussion with @joepavitt, this PR re-works ff dialogs to scroll inside their container, rather than the content.

Scrolling the entire dialog is similar to the approach by other CSS libraries and fixes the z-index and scrolling issues seen in the FlowForge dialogues (https://github.com/flowforge/flowforge/pull/1294, https://github.com/flowforge/flowforge/pull/1257, https://github.com/flowforge/flowforge/pull/1306).

### Before:

![2022-11-29 14 11 15](https://user-images.githubusercontent.com/507155/204527983-06a36f50-dadc-469b-99fe-a466cd0a2860.gif)

### After:
![2022-11-29 14 25 30](https://user-images.githubusercontent.com/507155/204528644-e3bd6580-d036-4802-88aa-95f610b5559c.gif)


