### PR TITLE
Workaround Vue.js virtual dom desync caused by innerHTML

### DIFF
--- a/src/directives/Tooltip.js
+++ b/src/directives/Tooltip.js
@@ -3,12 +3,17 @@ const directive = {
     mounted: (el, binding) => {
         if (el && binding) {
             el.classList.add('ff-tooltip-container')
+
             let posClass = 'ff-tooltip-right'
             if (binding.arg) {
                 posClass = 'ff-tooltip-' + binding.arg
             }
-            const tooltipDOM = `<span class="ff-tooltip ${posClass}">${binding.value}</span>`
-            el.innerHTML += tooltipDOM
+
+            const span = document.createElement('span')
+            span.className = `ff-tooltip ${posClass}`
+            span.innerHTML = binding.value
+
+            el.appendChild(span)
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/flowforge/forge-ui-components/issues/107, see that issue for more context.

Note: This isn't a "proper" fix (ideally UI-components shouldn't modify the DOM outside of Vue at all), but it unblocks us for now and we've sunk in a lot of time searching for a more permanent solution already.

Possible follow ups:

 - Move tooltips onto `body` the position them with JS
 - Remove the directive and create a wrapping component that adds tooltips to sections of the page
 - Create a sub view js context to handle the tooltips