### PR TITLE
Add full-height & scroll onto the nav section

### DIFF
--- a/docs/index.scss
+++ b/docs/index.scss
@@ -29,6 +29,8 @@ main {
 nav {
     position: absolute;
     width: 300px;
+    height: 100%;
+    overflow-y: auto;
 }
 
 nav.ff-bg-light {


### PR DESCRIPTION
## Description

https://user-images.githubusercontent.com/99246719/210976203-da2c4025-dfa4-42a1-ab71-52df38856ca0.mov

Just a minor CSS fix so that the nav bar fills the vertical space, and then overflows with `scroll` rather than cropping as it was currently.

## Related Issue(s)

Fixes #57 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)