### PR TITLE
Allow `ff-radio-group` options to be set dynamically

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -482,19 +482,19 @@
                 <div class="examples">
                     <div class="example">
                         <h5>Example 1: Horizontal</h5>
-                        <ff-radio-group v-model="models.radio0" :options="[{label: 'Option 1', value: 1, checked: true}, {label: 'Option 2', value: 2}]"></ff-radio-group>
+                        <ff-radio-group v-model="models.radio0" :options="[{label: 'Option 1', value: 1, checked: false}, {label: 'Option 2', value: 2}]"></ff-radio-group>
                         {{ models.radio0 }}
                         <code>{{ cGroups['input'].components[3].examples[0].code }}</code>
                     </div>
                     <div class="example">
                         <h5>Example 2: Vertical &amp; Descriptions</h5>
-                        <ff-radio-group v-model="models.radio1" label="We can also provide a label here" :options="[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Option 2', value: 2, description: 'Another description'}]" orientation="vertical"></ff-radio-group>
+                        <ff-radio-group v-model="models.radio1" label="We can also provide a label here" :options="[{label: 'Option 1', value: 1, checked: false, description: 'This is a description of this particular option'}, {label: 'Option 2', value: 2, description: 'Another description'}]" orientation="vertical"></ff-radio-group>
                         {{ models.radio1 }}
                         <code>{{ cGroups['input'].components[3].examples[1].code }}</code>
                     </div>
                     <div class="example">
                         <h5>Example 3: Disabled Option</h5>
-                        <ff-radio-group v-model="models.radio2" label="We can also provide a label here" :options="[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Disabled Option', value: 2, description: 'Another description', disabled: true}]" orientation="vertical"></ff-radio-group>
+                        <ff-radio-group v-model="models.radio2" label="We can also provide a label here" :options="[{label: 'Option 1', value: 1, checked: false, description: 'This is a description of this particular option'}, {label: 'Disabled Option', value: 2, description: 'Another description', disabled: true}]" orientation="vertical"></ff-radio-group>
                         {{ models.radio2 }}
                         <code>{{ cGroups['input'].components[3].examples[2].code }}</code>
                     </div>

--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -496,7 +496,7 @@
                         <h5>Example 3: Disabled Option</h5>
                         <ff-radio-group v-model="models.radio2" label="We can also provide a label here" :options="[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Disabled Option', value: 2, description: 'Another description', disabled: true}]" orientation="vertical"></ff-radio-group>
                         {{ models.radio2 }}
-                        <code>{{ cGroups['input'].components[3].examples[1].code }}</code>
+                        <code>{{ cGroups['input'].components[3].examples[2].code }}</code>
                     </div>
                 </div>
                 <!-- Tile Selection -->

--- a/docs/data/input.docs.json
+++ b/docs/data/input.docs.json
@@ -93,6 +93,8 @@
             "code": "<ff-radio-group v-model=\"myVar\" :options=\"[{label: 'Option 1', value: 1, checked: true}, {label: 'Option 2', value: 2}]\"></ff-radio-group>"
         }, {
             "code": "<ff-radio-group label=\"We can also provide a label here\" v-model=\"myVar\" orientation=\"vertical\" :options=\"[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Option 2', value: 2, description: 'Another description'}]\"></ff-radio-group>"
+        }, {
+            "code": "<ff-radio-group label=\"We can also provide a label here\" v-model=\"myVar\" orientation=\"vertical\" :options=\"[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Disabled Options', disabled: true, value: 2, description: 'Another description'}]\"></ff-radio-group>"
         }],
         "props": [{
             "key": "options",

--- a/docs/data/input.docs.json
+++ b/docs/data/input.docs.json
@@ -90,11 +90,11 @@
     }, {
         "name": "ff-radio-group",
         "examples": [{
-            "code": "<ff-radio-group v-model=\"myVar\" :options=\"[{label: 'Option 1', value: 1, checked: true}, {label: 'Option 2', value: 2}]\"></ff-radio-group>"
+            "code": "<ff-radio-group v-model=\"myVar\" :options=\"[{label: 'Option 1', value: 1, checked: false}, {label: 'Option 2', value: 2}]\"></ff-radio-group>"
         }, {
-            "code": "<ff-radio-group label=\"We can also provide a label here\" v-model=\"myVar\" orientation=\"vertical\" :options=\"[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Option 2', value: 2, description: 'Another description'}]\"></ff-radio-group>"
+            "code": "<ff-radio-group label=\"We can also provide a label here\" v-model=\"myVar\" orientation=\"vertical\" :options=\"[{label: 'Option 1', value: 1, checked: false, description: 'This is a description of this particular option'}, {label: 'Option 2', value: 2, description: 'Another description'}]\"></ff-radio-group>"
         }, {
-            "code": "<ff-radio-group label=\"We can also provide a label here\" v-model=\"myVar\" orientation=\"vertical\" :options=\"[{label: 'Option 1', value: 1, checked: true, description: 'This is a description of this particular option'}, {label: 'Disabled Options', disabled: true, value: 2, description: 'Another description'}]\"></ff-radio-group>"
+            "code": "<ff-radio-group label=\"We can also provide a label here\" v-model=\"myVar\" orientation=\"vertical\" :options=\"[{label: 'Option 1', value: 1, checked: false, description: 'This is a description of this particular option'}, {label: 'Disabled Options', disabled: true, value: 2, description: 'Another description'}]\"></ff-radio-group>"
         }],
         "props": [{
             "key": "options",

--- a/src/components/form/RadioGroup.vue
+++ b/src/components/form/RadioGroup.vue
@@ -33,9 +33,9 @@ export default {
         }
     },
     emits: ['update:modelValue'],
-    data () {
-        return {
-            internalOptions: this.options
+    computed: {
+        internalOptions () {
+            return this.options
         }
     },
     watch: {


### PR DESCRIPTION
## Description

This changes `ff-radio-group`'s `internalOptions` property to be computed. This allows the list of options to be modified dynamically. Without it, the list would be generated from the initial value of `options`, but any changes would be ignored.

Now... I will admit, I don't immediately see a purpose for `internalOptions` to exist at all - and whether it could actually use `this.options` directly. So I suspect there is a Vue-ism I am missing here. However, this change does appear to resolve the issue I was hitting and I don't see any unexpected side-effects in my uses of `ff-radio-group`.

## Related Issue(s)

 - #116 
 - #117

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

