### PR TITLE
Ensure RadioGroup checked option is maintained after option update

### DIFF
--- a/src/components/form/RadioGroup.vue
+++ b/src/components/form/RadioGroup.vue
@@ -41,6 +41,9 @@ export default {
     watch: {
         modelValue: function () {
             this.checkOptions()
+        },
+        internalOptions: function () {
+            this.checkOptions()
         }
     },
     mounted () {


### PR DESCRIPTION
## Description

Following up on #118, I found that the radio group would 'forget' which one was checked if the options object was ever updated.

This PR fixes that by adding a watch on it to trigger the internal handling to ensure the right option is checked.
