### PR TITLE
Allow Objects & Arrays in Dropdown Options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowforge/forge-ui-components",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "",
     "author": {
         "name": "FlowForge Inc."

--- a/src/components/form/Dropdown.vue
+++ b/src/components/form/Dropdown.vue
@@ -29,7 +29,7 @@ export default {
     props: {
         modelValue: {
             default: null,
-            type: [Number, String, Boolean]
+            type: [Number, String, Boolean, Object, Array]
         },
         placeholder: {
             default: 'Please Select',

--- a/src/components/form/DropdownOption.vue
+++ b/src/components/form/DropdownOption.vue
@@ -10,7 +10,7 @@ export default {
     props: {
         value: {
             default: null,
-            type: [Number, String, Boolean]
+            type: [Number, String, Boolean, Array, Object]
         },
         label: {
             default: null,


### PR DESCRIPTION
## Description

- Enables Objects and Arrays to be assigned to Dropdown 
- Jumps `package.json` to `0.5.2` to we can cut a new release.

## Related Issue(s)

No Issue

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)