### PR TITLE
Add focus and keyboard interaction to checkbox, button, radios and tile selections

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -1,4 +1,10 @@
 <template>
+    <!-- Used to show interactivity -->
+    <div style="position: absolute;right: 12px;top: 12px;z-index: 10;min-width: 350px;">
+        <ff-notification-toast v-for="(a, $index) in alerts.slice().reverse()" :key="a.timestamp"
+                               :type="a.type" :message="a.message"
+                               :countdown="a.countdown || 3000" @close="clearAlert($index)" />
+    </div>
     <nav :class="{'ff-bg-light': theme === 'light', 'ff-bg-dark': theme === 'dark'}">
         <h2 class="">Components</h2>
         <ul id="grouplist">
@@ -588,7 +594,7 @@
                                 We can also define content using a slot instead, and use the actions slot to add our own buttons
                             </template>
                             <template v-slot:actions>
-                                <ff-button @click="doSomething()">Example</ff-button>
+                                <ff-button @click="doSomething('Slot example')">Example</ff-button>
                             </template>
                         </ff-notification-toast>
                         <code>{{ cGroups['notifications'].components[1].examples[4].code }}</code>
@@ -721,6 +727,7 @@ export default {
     data () {
         return {
             theme: 'light',
+            alerts: [],
             models: {
                 dialog0: '',
                 textInput0: '',
@@ -950,8 +957,24 @@ export default {
         pretty: function (value) {
             return JSON.stringify(value, null, 2)
         },
-        rowSelected () {
-            console.log('row selected')
+        doSomething (message) {
+            this.displayAlert(message, 'info')
+        },
+        /**
+         * @param {string} msg The message to show
+         * @param {'info'|'confirmation'|'warning'} [type] Toast style
+         * @param {number} [countdown] How long to show (defaults to 3s)
+         */
+        displayAlert (msg, type, countdown) {
+            this.alerts.push({
+                message: msg,
+                type,
+                countdown,
+                timestamp: Date.now()
+            })
+        },
+        clearAlert (i) {
+            this.alerts.splice(this.alerts.length - 1 - i, 1)
         }
     }
 }

--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -44,10 +44,12 @@
                 <props-table :rows="cGroups['button'].components[0].props"></props-table>
                 <h3>Slots:</h3>
                 <slots-table :rows="cGroups['button'].components[0].slots"></slots-table>
+                <h3>Methods:</h3>
+                <methods-table :rows="cGroups['button'].components[0].methods" @callMethod="this.$refs['button-input']?.[$event]()"></methods-table>
                 <h3>Examples:</h3>
                 <div class="examples">
                     <div class="example">
-                        <ff-button>Hello World</ff-button>
+                        <ff-button ref="button-input" @click="doSomething('Button clicked')">Hello World</ff-button>
                         <code>{{ cGroups['button'].components[0].examples[0].code }}</code>
                     </div>
                     <div class="example">

--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -490,11 +490,13 @@
                 <h2 ref="ff-radio-group"><pre>ff-radio-group</pre></h2>
                 <h3>Properties:</h3>
                 <props-table :rows="cGroups['input'].components[3].props"></props-table>
+                <h3>Methods:</h3>
+                <methods-table :rows="cGroups['input'].components[3].methods" @callMethod="this.$refs['radio-group-input']?.[$event]()"></methods-table>
                 <h3>Examples:</h3>
                 <div class="examples">
                     <div class="example">
                         <h5>Example 1: Horizontal</h5>
-                        <ff-radio-group v-model="models.radio0" :options="[{label: 'Option 1', value: 1, checked: false}, {label: 'Option 2', value: 2}]"></ff-radio-group>
+                        <ff-radio-group ref="radio-group-input" v-model="models.radio0" :options="[{label: 'Option 1', value: 1, checked: false}, {label: 'Option 2', value: 2}]"></ff-radio-group>
                         {{ models.radio0 }}
                         <code>{{ cGroups['input'].components[3].examples[0].code }}</code>
                     </div>

--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -171,7 +171,7 @@
                     <div class="example">
                         <h5>Example 4: Filtering via Search &amp; Actions</h5>
                         <ff-data-table :columns="data.table3.columns" :rows="data.table3.rows"
-                            :show-search="true" search-placeholder="Search here..." v-model:search="data.table3.search">
+                                       :show-search="true" search-placeholder="Search here..." v-model:search="data.table3.search">
                             <template v-slot:actions>
                                 <ff-button>Press Me!</ff-button>
                                 <ff-button>Click Me!</ff-button>
@@ -216,7 +216,7 @@
                         </p>
                         <p style="margin-bottom: 12px;">This method does still enable searching and sorting out of the box.</p>
                         <ff-data-table :columns="data.table4.columns" :rows="data.table4.rows"
-                            :show-search="true" :search-fields="['sName', 'number']" search-placeholder="search-fields limits which properties the search applies to."></ff-data-table>
+                                       :show-search="true" :search-fields="['sName', 'number']" search-placeholder="search-fields limits which properties the search applies to."></ff-data-table>
                         <code style="margin-top: 24px;">{{ cGroups['data-table'].components[0].examples[8].code }}</code>
                         <code style="margin-top: 24px;">cols = {{ pretty(data.table4DocVersion.columns) }}</code>
                     </div>
@@ -309,7 +309,7 @@
                         <ff-button @click="$refs['dialog0'].show()">Show Dialog</ff-button>
                         <ff-dialog ref="dialog0" header="My Dialog Box" :disable-primary="!models.dialog0">
                             <p style="margin-bottom: 12px">The main message for the dialog box goes here. We can put any elements we like here.
-                            For example, a text input:</p>
+                                For example, a text input:</p>
                             <ff-text-input placeholder="My Text Input" v-model="models.dialog0"/>
                         </ff-dialog>
                         <code>{{ cGroups['dialog'].components[0].examples[0].code }}</code>
@@ -453,11 +453,13 @@
                 <h2 ref="ff-checkbox"><pre>ff-checkbox</pre></h2>
                 <h3>Properties:</h3>
                 <props-table :rows="cGroups['input'].components[2].props"></props-table>
+                <h3>Methods:</h3>
+                <methods-table :rows="cGroups['input'].components[2].methods" @callMethod="this.$refs['checkbox-input']?.[$event]()"></methods-table>
                 <h3>Examples:</h3>
                 <div class="examples">
                     <div class="example">
                         <h5>Example 1: Default</h5>
-                        <ff-checkbox label="My Checkbox" v-model="models.checkbox0"></ff-checkbox>
+                        <ff-checkbox label="My Checkbox" v-model="models.checkbox0" ref="checkbox-input"></ff-checkbox>
                         {{ models.checkbox0 }}
                         <code>{{ cGroups['input'].components[2].examples[0].code }}</code>
                     </div>

--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -538,8 +538,8 @@
                     </div>
                     <div class="example">
                         <ff-tile-selection>
-                            <ff-tile-selection-option :editable="true" value="1" label="Option 1" :description="'Markdown supported in the description.'" price="$15.00" price-interval="/month" :meta="[{key: 'a', value: 1}, {key: 'b', value: 2}]"/>
-                            <ff-tile-selection-option :editable="true" value="2" label="Option 2" :description="'\n * So we can offer bullet point lists\n* That help summarise the selection option'" price="$50.00" price-interval="/month" :meta="[{key: 'c', value: 3}, {key: 'd', value: 4}]"/>
+                            <ff-tile-selection-option @edit="doSomething('Triggered edit on option 1')" :editable="true" value="1" label="Option 1" :description="'Markdown supported in the description.'" price="$15.00" price-interval="/month" :meta="[{key: 'a', value: 1}, {key: 'b', value: 2}]"/>
+                            <ff-tile-selection-option @edit="doSomething('Triggered edit on option 2')"  :editable="true" value="2" label="Option 2" :description="'\n * So we can offer bullet point lists\n* That help summarise the selection option'" price="$50.00" price-interval="/month" :meta="[{key: 'c', value: 3}, {key: 'd', value: 4}]"/>
                         </ff-tile-selection>
                         <code>{{ cGroups['input'].components[4].examples[2].code }}</code>
                     </div>

--- a/docs/data/button.docs.json
+++ b/docs/data/button.docs.json
@@ -48,6 +48,13 @@
         }, {
             "name": "icon-right",
             "description": "Can be used to add an icon to the right of any value/label"
+        }],
+        "methods": [{
+            "name": "focus",
+            "description": "Focuses on the element"
+        },{
+            "name": "blur",
+            "description": "Removes focus from the element"
         }]
     }, {
         "name": "ff-kebab-menu",

--- a/docs/data/input.docs.json
+++ b/docs/data/input.docs.json
@@ -179,6 +179,13 @@
             "key": "meta",
             "default": "null",
             "description": "An array of objects. Each object will be shown as a key/value pair in a table."
+        }],
+        "methods": [{
+            "name": "focus",
+            "description": "Focuses on the first time selection"
+        },{
+            "name": "blur",
+            "description": "Removes focus from all tile selections"
         }]
     }]
 }

--- a/docs/data/input.docs.json
+++ b/docs/data/input.docs.json
@@ -117,11 +117,18 @@
         }, {
             "key": "label",
             "default": "''",
-            "description": "(optional) Use this to provide guidance/intructions for what the radio buttons are being used for."
+            "description": "(optional) Use this to provide guidance/instructions for what the radio buttons are being used for."
         }, {
             "key": "orientation",
             "default": "horizontal",
             "description": "(optional) The direction that the radio group renders."
+        }],
+        "methods": [{
+            "name": "focus",
+            "description": "Focuses on the first radio button"
+        },{
+            "name": "blur",
+            "description": "Removes focus from the element"
         }]
     }, {
         "name": "ff-tile-selection",

--- a/docs/data/input.docs.json
+++ b/docs/data/input.docs.json
@@ -93,6 +93,13 @@
             "key": "disabled",
             "default": "false",
             "description": "Whether or not the checkbox can be toggled."
+        }],
+        "methods": [{
+            "name": "focus",
+            "description": "Focuses on the element"
+        },{
+            "name": "blur",
+            "description": "Removes focus from the element"
         }]
     }, {
         "name": "ff-radio-group",

--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -1,5 +1,5 @@
 <template>
-    <button class="ff-btn transition-fade--color" :type="type" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" @click="go()">
+    <button ref="input" class="ff-btn transition-fade--color" :type="type" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" @click="go()">
         <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
             <slot name="icon-left"></slot>
         </span>
@@ -53,6 +53,12 @@ export default {
             if (this.to) {
                 this.$router.push(this.to)
             }
+        },
+        focus () {
+            this.$refs.input?.focus()
+        },
+        blur () {
+            this.$refs.input?.blur()
         }
     }
 }

--- a/src/components/form/Checkbox.vue
+++ b/src/components/form/Checkbox.vue
@@ -1,8 +1,8 @@
 <template>
     <label class="ff-checkbox" :disabled="disabled">
-        <input type="checkbox" :value="modelValue" :disabled="disabled" v-model="model" />
-        <span class="checkbox" :checked="model"></span>
-        <label @click="toggle" v-if="label !== null || $slots.default">
+        <input v-model="model" type="checkbox" :value="modelValue" :disabled="disabled" />
+        <span class="checkbox" :checked="model" ref="input" tabindex="0" @keydown.space.stop.prevent="toggle"></span>
+        <label v-if="label !== null || $slots.default" @click="toggle">
             <slot>{{ label }}</slot>
         </label>
     </label>
@@ -37,6 +37,12 @@ export default {
         }
     },
     methods: {
+        focus () {
+            this.$refs.input?.focus()
+        },
+        blur () {
+            this.$refs.input?.blur()
+        },
         toggle () {
             if (!this.disabled) {
                 this.model = !this.model

--- a/src/components/form/Checkbox.vue
+++ b/src/components/form/Checkbox.vue
@@ -1,7 +1,7 @@
 <template>
     <label class="ff-checkbox" :disabled="disabled">
         <input v-model="model" type="checkbox" :value="modelValue" :disabled="disabled" />
-        <span class="checkbox" :checked="model" ref="input" tabindex="0" @keydown.space.stop.prevent="toggle"></span>
+        <span ref="input" class="checkbox" :checked="model" tabindex="0" @keydown.space.stop.prevent="toggle"></span>
         <label v-if="label !== null || $slots.default" @click="toggle">
             <slot>{{ label }}</slot>
         </label>

--- a/src/components/form/Checkbox.vue
+++ b/src/components/form/Checkbox.vue
@@ -1,7 +1,7 @@
 <template>
     <label class="ff-checkbox" :disabled="disabled">
         <input v-model="model" type="checkbox" :value="modelValue" :disabled="disabled" />
-        <span ref="input" class="checkbox" :checked="model" tabindex="0" @keydown.space.stop.prevent="toggle"></span>
+        <span ref="input" class="checkbox" :checked="model" tabindex="0" @keydown.space.prevent="toggle"></span>
         <label v-if="label !== null || $slots.default" @click="toggle">
             <slot>{{ label }}</slot>
         </label>

--- a/src/components/form/Dropdown.vue
+++ b/src/components/form/Dropdown.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="ff-dropdown" :class="'ff-dropdown--' + (isOpen ? 'open' : 'closed')" :disabled="disabled">
-        <div v-if="dropdownStyle === 'select'" ref="dropdownLabel" class="ff-dropdown-selected" tabindex="0" @click="open()" @keydown.space.stop.prevent="open()">
+        <div v-if="dropdownStyle === 'select'" ref="dropdownLabel" class="ff-dropdown-selected" tabindex="0" @click="open()" @keydown.space.prevent="open()">
             <slot name="placeholder">
                 {{ selected?.label || placeholder }}
             </slot>

--- a/src/components/form/RadioButton.vue
+++ b/src/components/form/RadioButton.vue
@@ -1,7 +1,7 @@
 <template>
     <label class="ff-radio-btn" :disabled="disabled" @click="select(value)">
         <input type="radio" :value="value" />
-        <span class="checkbox" :checked="checked"></span>
+        <span ref="input" class="checkbox" :checked="checked" tabindex="0" @keydown.space.prevent="select(value)"></span>
         <label>{{ label }}</label>
         <p v-if="description && !hideDescription" class="ff-description">{{ description }}</p>
     </label>
@@ -42,6 +42,12 @@ export default {
             if (!this.disabled) {
                 this.$emit('select', value)
             }
+        },
+        focus () {
+            this.$refs.input?.focus()
+        },
+        blur () {
+            this.$refs.input?.blur()
         }
     }
 }

--- a/src/components/form/RadioGroup.vue
+++ b/src/components/form/RadioGroup.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="ff-radio-group" :class="'ff-radio-group--' + orientation">
-        <label class="ff-radio-group-label" v-if="label">{{ label }}</label>
-        <ff-radio-button v-for="option in internalOptions" :key="option.label"
+        <label v-if="label" class="ff-radio-group-label">{{ label }}</label>
+        <ff-radio-button v-for="option in internalOptions" :key="option.label" ref="inputs"
             :value="option.value" :label="option.label" :checked="option.checked"
             :description="option.description"
             :disabled="option.disabled"
@@ -60,6 +60,14 @@ export default {
                     this.$emit('update:modelValue', option.value)
                 }
             })
+        },
+        focus () {
+            this.$refs.inputs?.[0]?.focus()
+        },
+        blur () {
+            for (const input of this.$refs.inputs) {
+                input.blur()
+            }
         }
     }
 }

--- a/src/components/form/TileSelection.vue
+++ b/src/components/form/TileSelection.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="ff-tile-selection" ref="options">
+    <div ref="options" class="ff-tile-selection">
         <slot name="default"></slot>
     </div>
 </template>
@@ -8,11 +8,17 @@
 
 export default {
     name: 'ff-tile-selection',
-    emits: ['update:modelValue'],
     props: {
         modelValue: {
             default: null,
             type: [String, Number]
+        }
+    },
+    emits: ['update:modelValue'],
+    data () {
+        return {
+            selected: null,
+            children: []
         }
     },
     watch: {
@@ -22,11 +28,16 @@ export default {
             })
         }
     },
-    data () {
-        return {
-            selected: null,
-            children: []
-        }
+    mounted () {
+        this.$nextTick(() => {
+            for (let i = 0; i < this.children.length; i++) {
+                if (this.modelValue !== this.children[i].value) {
+                    this.children[i].selected = false
+                } else {
+                    this.children[i].selected = true
+                }
+            }
+        })
     },
     methods: {
         registerOption: function (child) {
@@ -44,18 +55,15 @@ export default {
             for (let i = 0; i < this.children.length; i++) {
                 this.children[i].selected = value === this.children[i].value
             }
-        }
-    },
-    mounted () {
-        this.$nextTick(() => {
-            for (let i = 0; i < this.children.length; i++) {
-                if (this.modelValue !== this.children[i].value) {
-                    this.children[i].selected = false
-                } else {
-                    this.children[i].selected = true
-                }
+        },
+        focus () {
+            this.children?.[0].focus()
+        },
+        blur () {
+            for (const child of this.children) {
+                child.blur()
             }
-        })
+        }
     }
 }
 </script>

--- a/src/components/form/TileSelectionOption.vue
+++ b/src/components/form/TileSelectionOption.vue
@@ -79,6 +79,10 @@ export default {
     },
     methods: {
         select (allowEdit = false) {
+            if (this.disabled) {
+                return
+            }
+
             if (!this.editable) {
                 this.$parent.setSelected({
                     value: this.value,

--- a/src/components/form/TileSelectionOption.vue
+++ b/src/components/form/TileSelectionOption.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="ff-tile-selection-option" :class="{'editable': editable, 'disabled': disabled, 'active': selected}" @click="select()">
+    <div ref="input" class="ff-tile-selection-option" :class="{'editable': editable, 'disabled': disabled, 'active': selected}" tabindex="0" @click="select(false)" @keydown.space.prevent="select(true)">
         <div class="ff-tile-selection-option--header">
             <h2>
-                <PencilAltIcon class="ff-tile-selection-option--edit" v-if="editable" @click="$emit('edit')" />
+                <PencilAltIcon v-if="editable" class="ff-tile-selection-option--edit" @click="select(true)" />
                 <CheckCircleIcon v-else />
                 {{ label }}
             </h2>
@@ -30,7 +30,10 @@ import { CheckCircleIcon, PencilAltIcon } from '@heroicons/vue/solid'
 
 export default {
     name: 'ff-tile-selection-option',
-    emits: ['edit'],
+    components: {
+        CheckCircleIcon,
+        PencilAltIcon
+    },
     props: {
         value: {
             required: true,
@@ -65,10 +68,7 @@ export default {
             type: Array
         }
     },
-    components: {
-        CheckCircleIcon,
-        PencilAltIcon
-    },
+    emits: ['edit'],
     data () {
         return {
             selected: false
@@ -78,7 +78,7 @@ export default {
         this.$parent.registerOption(this)
     },
     methods: {
-        select () {
+        select (allowEdit = false) {
             if (!this.editable) {
                 this.$parent.setSelected({
                     value: this.value,
@@ -87,7 +87,15 @@ export default {
                     price: this.price
                 })
                 this.selected = !this.selected
+            } else if (allowEdit) {
+                this.$emit('edit')
             }
+        },
+        focus () {
+            this.$refs.input?.focus()
+        },
+        blur () {
+            this.$refs.input?.blur()
         }
     }
 }


### PR DESCRIPTION
## Description

Updates the checkbox, button, radio, and tile-selection components to:

 - Support focus and blur
 - Be selectable with tab navigation
 - Support keyboard interaction (i.e. space to select/toggle)

Also adds a basic alert demo to the docs to be able to show component event handling in action.

This is easiest to get a feel for by running locally, but here are some screenshots:

<img width="985" alt="Screenshot 2023-02-16 at 11 50 47" src="https://user-images.githubusercontent.com/507155/219348408-43d88e8f-2216-4110-a0b5-05b0387511f3.png">
<img width="976" alt="Screenshot 2023-02-16 at 11 51 11" src="https://user-images.githubusercontent.com/507155/219348413-e4bbd5f9-249b-452c-a333-23355fe3bc07.png">
<img width="996" alt="Screenshot 2023-02-16 at 11 51 20" src="https://user-images.githubusercontent.com/507155/219348415-2fb48479-a0fb-4b92-8d08-2a8065dbd95d.png">
<img width="1005" alt="Screenshot 2023-02-16 at 12 05 33" src="https://user-images.githubusercontent.com/507155/219348417-34af39ea-e785-48c7-a7ba-983a79fd43d5.png">
<img width="466" alt="Screenshot 2023-02-16 at 12 05 41" src="https://user-images.githubusercontent.com/507155/219348419-8b37c6fe-ae05-4f7d-aaae-75cd4764c438.png">

## Related Issue(s)

For #42 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)

