### PR TITLE
Fix dropdown text overflow

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -112,7 +112,7 @@
                     </div>
                     <div class="example">
                         <h5>Right-Aligned Options</h5>
-                        <ff-kebab-menu style="margin-left: 150px;" menu-align="right">
+                        <ff-kebab-menu style="margin-left: 250px;" menu-align="right">
                             <ff-list-item label="Option 1" />
                             <ff-list-item label="Option 2" />
                         </ff-kebab-menu>
@@ -426,16 +426,23 @@
                             <ff-dropdown-option label="Option 3" :value="3"></ff-dropdown-option>
                         </ff-dropdown>
                         {{ models.dropdown0 }}
+
+                        <ff-dropdown v-model="models.dropdown1" ref="dropbox-input" style="width: 100px">
+                            <ff-dropdown-option label="Very long options" :value="1"></ff-dropdown-option>
+                            <ff-dropdown-option label="They're so long I don't know what to choose" :value="2"></ff-dropdown-option>
+                            <ff-dropdown-option label="This on is also long" :value="3"></ff-dropdown-option>
+                        </ff-dropdown>
+                        {{ models.dropdown1 }}
                         <code>{{ cGroups['input'].components[1].examples[0].code }}</code>
                     </div>
                     <div class="example">
                         <h5>Button Style</h5>
-                        <ff-dropdown v-model="models.dropdown1" placeholder="Dropdown Button" dropdown-style="button">
+                        <ff-dropdown v-model="models.dropdown2" placeholder="Dropdown Button" dropdown-style="button">
                             <ff-dropdown-option label="Option 1" :value="1"></ff-dropdown-option>
                             <ff-dropdown-option label="Option 2" :value="2"></ff-dropdown-option>
                             <ff-dropdown-option label="Option 3" :value="3"></ff-dropdown-option>
                         </ff-dropdown>
-                        {{ models.dropdown1 }}
+                        {{ models.dropdown2 }}
                         <code>{{ cGroups['input'].components[1].examples[1].code }}</code>
                     </div>
                     <div class="example">
@@ -736,7 +743,8 @@ export default {
                 dialog0: '',
                 textInput0: '',
                 dropdown0: 1,
-                dropdown1: null,
+                dropdown1: 2,
+                dropdown2: null,
                 checkbox0: false,
                 checkbox1: false,
                 checkbox2: false,

--- a/src/components/form/Dropdown.vue
+++ b/src/components/form/Dropdown.vue
@@ -2,9 +2,11 @@
     <div class="ff-dropdown" :class="'ff-dropdown--' + (isOpen ? 'open' : 'closed')" :disabled="disabled">
         <div v-if="dropdownStyle === 'select'" ref="dropdownLabel" class="ff-dropdown-selected" tabindex="0" @click="open()" @keydown.space.prevent="open()">
             <slot name="placeholder">
-                {{ selected?.label || placeholder }}
+                <div class="ff-dropdown-selected-item">
+                    {{ selected?.label || placeholder }}
+                </div>
             </slot>
-            <ChevronDownIcon class="ff-icon ff-btn--icon-right" />
+            <ChevronDownIcon class="ff-icon ff-btn--icon-right ff-dropdown-icon" />
         </div>
         <ff-button v-else-if="dropdownStyle === 'button'" @click="open()">
             {{ placeholder }}

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -277,6 +277,17 @@ li.ff-list-item {
     display: flex;
     justify-content: space-between;
     z-index: 2;
+
+    > .ff-dropdown-selected-item {
+      flex-shrink: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    > .ff-dropdown-icon {
+      flex-shrink: 0;
+    }
   }
   .ff-dropdown-options {
     position: absolute;


### PR DESCRIPTION
## Description

### Before
Text overflows and dropdown icon missing
<img width="275" alt="Screenshot 2023-03-08 at 16 21 52" src="https://user-images.githubusercontent.com/507155/223753759-668e0fef-b946-4d82-a792-8dea807bdd37.png">

### After
Text cropped and dropdown icon visible
<img width="294" alt="Screenshot 2023-03-08 at 16 19 51" src="https://user-images.githubusercontent.com/507155/223753787-3f89490e-1252-49fb-aa0d-bf8012fe6173.png">

## Related Issue(s)

Fixes #126

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

