### PR TITLE
Add yellow palette to color variables

### DIFF
--- a/src/stylesheets/ff-colors.scss
+++ b/src/stylesheets/ff-colors.scss
@@ -70,6 +70,17 @@ $ff-green-700: #047857;
 $ff-green-800: #065F46;
 $ff-green-900: #064E3B;
 
+$ff-yellow-50: #FFFBEB;
+$ff-yellow-100: #FEF3C7;
+$ff-yellow-200: #FDE68A;
+$ff-yellow-300: #FCD34D;
+$ff-yellow-400: #FBBF24;
+$ff-yellow-500: #F59E0B;
+$ff-yellow-600: #D97706;
+$ff-yellow-700: #B45309;
+$ff-yellow-800: #92400E;
+$ff-yellow-900: #78350F;
+
 // Theme Colors
 
 $ff-color--action: $ff-blue-900;


### PR DESCRIPTION
## Description

Hadn't included the yellow palette in our color variables - need to sue them for some charting.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)