### PR TITLE
Fixed radio-btn default state when value set

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -503,7 +503,7 @@
                 <div class="examples">
                     <div class="example">
                         <h5>Example 1: Horizontal</h5>
-                        <ff-radio-group ref="radio-group-input" v-model="models.radio0" :options="[{label: 'Option 1', value: 1, checked: false}, {label: 'Option 2', value: 2}]"></ff-radio-group>
+                        <ff-radio-group ref="radio-group-input" v-model="models.radio0" :options="[{label: 'Option 1', value: 1}, {label: 'Option 2', value: 2}]"></ff-radio-group>
                         {{ models.radio0 }}
                         <code>{{ cGroups['input'].components[3].examples[0].code }}</code>
                     </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowforge/forge-ui-components",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "",
     "author": {
         "name": "FlowForge Inc."

--- a/src/components/form/RadioGroup.vue
+++ b/src/components/form/RadioGroup.vue
@@ -33,9 +33,9 @@ export default {
         }
     },
     emits: ['update:modelValue'],
-    computed: {
-        internalOptions () {
-            return this.options
+    data: function () {
+        return {
+            internalOptions: this.options
         }
     },
     watch: {
@@ -57,6 +57,7 @@ export default {
             this.options.forEach((option, i) => {
                 this.internalOptions[i].checked = (option.value === this.modelValue)
                 if (this.internalOptions[i].checked) {
+                    // emit the new checked value v-model bound to this group
                     this.$emit('update:modelValue', option.value)
                 }
             })


### PR DESCRIPTION
## Description

Move internally stored state of `options` to the `data()` with a default value of `this.options`, rather than as a `computed` variable that _always_ returned `this.options`. Results in better local state management, whilst still ensuring state is communicated correctly to parent view and child buttons. Have tested this with an async example too.

Also bumping to 0.6.1 to create a new cut of ui-components.

Need to update ui-components to `v0.6.1` in `/flowforge/package.json` once this is merged

## Related Issue(s)

Closes #122
Closes https://github.com/flowforge/flowforge/issues/2084

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->

