### PR TITLE
0.6.2 - Ensure we update disabled, label and description with async changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowforge/forge-ui-components",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "",
     "author": {
         "name": "FlowForge Inc."

--- a/src/components/form/RadioGroup.vue
+++ b/src/components/form/RadioGroup.vue
@@ -55,6 +55,9 @@ export default {
         },
         checkOptions () {
             this.options.forEach((option, i) => {
+                this.internalOptions[i].label = option.label
+                this.internalOptions[i].description = option.description
+                this.internalOptions[i].disabled = option.disabled
                 this.internalOptions[i].checked = (option.value === this.modelValue)
                 if (this.internalOptions[i].checked) {
                     // emit the new checked value v-model bound to this group


### PR DESCRIPTION
## Description

With the introduction of `internalData` into the radio group, it made `disabled` out of sync if there was an async update of the data.

## Related Issue(s)

Fixes https://github.com/flowforge/flowforge/issues/2143

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
