### PR TITLE
Enable updating of tooltip values after "mounted"

### DIFF
--- a/src/directives/Tooltip.js
+++ b/src/directives/Tooltip.js
@@ -1,19 +1,41 @@
+function renderTooltip (el, binding, vnode) {
+    el.classList.add('ff-tooltip-container')
+
+    let posClass = 'ff-tooltip-right'
+    if (binding.arg) {
+        posClass = 'ff-tooltip-' + binding.arg
+    }
+
+    const span = document.createElement('span')
+    span.className = `ff-tooltip ${posClass}`
+    span.innerHTML = binding.value
+
+    el.appendChild(span)
+}
+
 const directive = {
     name: 'ff-tooltip',
     mounted: (el, binding) => {
-        if (el && binding) {
-            el.classList.add('ff-tooltip-container')
-
-            let posClass = 'ff-tooltip-right'
-            if (binding.arg) {
-                posClass = 'ff-tooltip-' + binding.arg
+        if (el && binding && binding.value) {
+            renderTooltip(el, binding)
+        }
+    },
+    updated (el, binding) {
+        if (binding.value) {
+            const tooltips = el.getElementsByClassName('ff-tooltip')
+            if (tooltips.length) {
+                // update existing tooltip
+                tooltips[0].innerHTML = binding.value
+            } else {
+                // render a new tooltip
+                renderTooltip(el, binding)
             }
-
-            const span = document.createElement('span')
-            span.className = `ff-tooltip ${posClass}`
-            span.innerHTML = binding.value
-
-            el.appendChild(span)
+        } else {
+            // remove all tooltips
+            const tooltips = el.getElementsByClassName('ff-tooltip')
+            for (let i = 0; i < tooltips.length; i++) {
+                tooltips[i].remove()
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Adding a tooltip to flowforge that explains the reason for a button being disabled. Polling enables the button to be re-enabled, but the tooltip wasn't equipped to auto-update.

## Related Issue(s)

Feature first required in https://github.com/flowforge/flowforge/pull/2210

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
