### PR TITLE
Architecture Updates: Theming & Fix up some components dark theming

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -5,7 +5,7 @@
                                :type="a.type" :message="a.message"
                                :countdown="a.countdown || 3000" @close="clearAlert($index)" />
     </div>
-    <nav :class="{'ff-bg-light': theme === 'light', 'ff-bg-dark': theme === 'dark'}">
+    <nav :class="{'ff-bg-light ff-theme-light': theme === 'light', 'ff-bg-dark ff-theme-dark': theme === 'dark'}">
         <h2 class="">Components</h2>
         <ul id="grouplist">
             <li v-for="g in cGroups" :key="g.name">
@@ -25,7 +25,7 @@
             </li>
         </ul>
     </nav>
-    <main :class="{'ff-bg-light': theme === 'light', 'ff-bg-dark': theme === 'dark'}">
+    <main :class="{'ff-bg-light ff-theme-light': theme === 'light', 'ff-bg-dark ff-theme-dark': theme === 'dark'}">
         <!-- Theme Selection -->
         <div class="theme-selection">
             <label>Theme:</label>
@@ -204,10 +204,10 @@
                         <p style="margin-bottom: 6px;">
                             <b>Map</b><br />
                         </p>
-                        <pre style="margin-bottom: 6px;">"map": {
+                        <code><pre style="margin-bottom: 6px;">"map": {
     "count": "number",
     "name": "user.name",
-},</pre>
+},</pre></code>
                         <p style="margin-bottom: 12px;">
                             Maps the row properties <code style="display:inline;">number</code> and <code style="display:inline;">user.name</code>
                             to <code style="display:inline;">number</code> and <code style="display:inline;">name</code> respectively.
@@ -215,10 +215,10 @@
                         <p style="margin-bottom: 6px;">
                             <b>extraProps</b><br />
                         </p>
-                        <pre  style="margin-bottom: 6px;">"extraProps": {
+                        <code><pre  style="margin-bottom: 6px;">"extraProps": {
     "total": this.totalRows,
     "disabled": this.tableDisabled,
-},</pre>
+},</pre></code>
                         <p style="margin-bottom: 12px;">
                             Passes the properties <code style="display:inline;">totalRows</code> and <code style="display:inline;">tableDisabled</code> from wherever columns is defined into the component.
                         </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowforge/forge-ui-components",
-    "version": "0.6.4",
+    "version": "0.7.0",
     "description": "",
     "author": {
         "name": "FlowForge Inc."

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -360,7 +360,8 @@ li.ff-list-item {
     width: 16px;
     border-radius: 4px;
     background-color: transparent;
-    border: 1px solid $ff-grey-400;    
+    border: 1px solid;
+    border-color: $ff-grey-400;    
   }
   &:hover:not([disabled=true]) {
     .checkbox {

--- a/src/stylesheets/ff-components.scss
+++ b/src/stylesheets/ff-components.scss
@@ -262,7 +262,6 @@ li.ff-list-item {
 .ff-dropdown {
   position: relative;
   display: inline-block;
-  background-color: white;
   cursor: pointer;
   &[disabled="true"] {
     cursor: not-allowed;
@@ -270,6 +269,7 @@ li.ff-list-item {
     color: $ff-grey-400;
   }
   .ff-dropdown-selected {
+    background-color: white;
     border: 1px solid $ff-grey-300;
     border-radius: $ff-unit-sm;
     padding: $ff-unit-sm $ff-unit-md;

--- a/src/stylesheets/ff-theme-dark.scss
+++ b/src/stylesheets/ff-theme-dark.scss
@@ -55,13 +55,41 @@
       }
     }
 
-    .checkbox {
-        &[checked=true] {
-            background-color: $ff-white;
-            border-color: $ff-grey-700;
+    .ff-checkbox {
+        .checkbox[checked=true] {
+            background-color: transparent;
         }
-        &[checked=true]:after {
-            display: block;
+        &:hover:not([disabled=true]) {
+            .checkbox {
+                background-color: $ff-grey-600;
+            }
+        }
+        &:hover:not([disabled=true]) {
+            .checkbox[checked=true] {
+                background-color: $ff-grey-800;
+            }
+        }
+    }
+    
+    .ff-radio-btn {
+        .checkbox {
+            &[checked=true] {
+                background-color: $ff-white;
+                border-color: $ff-grey-700;
+            }
+            &[checked=true]:after {
+                display: block;
+            }
+        }
+        &:hover:not([disabled=true]) {
+            .checkbox {
+                background-color: $ff-grey-600;
+            }
+        }
+        &:hover:not([disabled=true]) {
+            .checkbox[checked=true] {
+                background-color: $ff-white;
+            }
         }
     }
 }

--- a/src/stylesheets/ff-theme-dark.scss
+++ b/src/stylesheets/ff-theme-dark.scss
@@ -1,6 +1,9 @@
 .ff-bg-dark {
-    color: $ff-grey-50;
     background-color: $ff-grey-800;
+}
+
+.ff-theme-dark {
+    color: $ff-grey-50;
     
     /* Core */
 
@@ -25,9 +28,12 @@
 
     /* FlowForge Components */
 
+    /**
+    * Buttons
+    */
     .ff-btn {
         &--tertiary {
-            // color: $ff-teal-500;
+            color: $ff-white;
             &:hover {
                 // background-color: $ff-color--secondary--highlight;
                 color: $ff-white;
@@ -40,6 +46,10 @@
         }
     }
 
+    /**
+    *  Text Input
+    */
+
     .ff-input.ff-text-input {
         background-color: $ff-grey-700;
         border-color: $ff-grey-900;
@@ -48,12 +58,34 @@
         }
     }
 
-    .ff-radio-btn {
-      .checkbox {
-        border: 1px solid $ff-grey-600;
-        background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%231F2937' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='4'/%3e%3c/svg%3e")    
-      }
+    /**
+    *  Dropdowns
+    */
+
+    .ff-dropdown {
+        &[disabled="true"] {
+            background-color: $ff-grey-700;
+            color: $ff-grey-500;
+        }
+        .ff-dropdown-selected {
+            background-color: $ff-grey-700;
+            border-color: $ff-grey-500;
+        }
+        .ff-dropdown-options {
+            border-color: $ff-grey-700;
+        }
+        .ff-dropdown-option {
+            background-color: $ff-grey-700;
+            border-color: $ff-grey-800;
+            &:hover {
+                background-color: $ff-grey-800;
+            }
+        }
     }
+
+    /**
+    *  Checkboxes
+    */
 
     .ff-checkbox {
         .checkbox[checked=true] {
@@ -69,6 +101,17 @@
                 background-color: $ff-grey-800;
             }
         }
+    }
+
+    /**
+    *  Radio Group
+    */
+
+    .ff-radio-btn {
+      .checkbox {
+        border: 1px solid $ff-grey-600;
+        background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%231F2937' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='4'/%3e%3c/svg%3e")    
+      }
     }
     
     .ff-radio-btn {
@@ -92,4 +135,99 @@
             }
         }
     }
+
+    /**
+    *  Toast Notification
+    */
+
+    .ff-notification-toast {
+        color: $ff-grey-800;
+    }
+
+    /**
+    *  Selection Tile
+    */
+
+    .ff-tile-selection {
+        .ff-tile-selection-option--header > h2 svg {
+            fill: $ff-grey-500;
+            &.ff-tile-selection-option--edit:hover {
+                fill: $ff-blue-300;
+            }
+        }
+        .ff-tile-selection-option {
+            background-color: $ff-grey-700;
+            border-color: $ff-grey-800;
+            &.active svg {
+                fill: $ff-blue-300;
+            }
+            &:hover {
+                background-color: $ff-grey-800;
+            }
+            &:not(.editable):hover {
+                border-color: $ff-blue-300;
+            }
+            &[selected=true] {
+                background-color: $ff-grey-800;
+                border-color: $ff-grey-800;
+            }
+        }
+    }
+
+    /**
+    *  Data Table
+    */
+    .ff-data-table {
+        &--data {
+          .ff-data-table--cell {
+          }
+          thead {
+            .ff-data-table--cell {
+              background-color: $ff-grey-900;
+              &.sortable {
+                &:hover {
+                  background-color: $ff-grey-800;
+                }
+              }
+              &.sorted {
+                background-color: $ff-grey-900;
+              }
+            }
+          }
+          tbody {
+            .ff-data-table--row:last-child {
+              .ff-data-table--cell {
+                border-top-color: $ff-grey-600;
+              }
+            }
+            .ff-data-table--cell {
+              background-color: $ff-grey-700;
+              &.highlight {
+                background-color: $ff-grey-800;
+              }
+            }
+            .selectable:hover .ff-data-table--cell {
+              color: $ff-blue-300;
+              background-color: $ff-grey-600;
+            }
+          }
+        }
+        &--row {
+          td {
+            border-color: $ff-grey-600;
+          }
+        }
+      }
+      
+      .ff-loadmore {
+        span {
+          color: $ff-white;
+          background-color: $ff-grey-900;
+          border: 1px solid $ff-grey-600;
+          &:hover {
+            color: $ff-blue-300;
+            background-color: $ff-grey-600;
+          }
+        }
+      }
 }

--- a/src/stylesheets/ff-theme-dark.scss
+++ b/src/stylesheets/ff-theme-dark.scss
@@ -90,6 +90,7 @@
     .ff-checkbox {
         .checkbox[checked=true] {
             background-color: transparent;
+            border-color: $ff-grey-500;
         }
         &:hover:not([disabled=true]) {
             .checkbox {
@@ -99,6 +100,7 @@
         &:hover:not([disabled=true]) {
             .checkbox[checked=true] {
                 background-color: $ff-grey-800;
+                border-color: $ff-grey-600;
             }
         }
     }

--- a/src/stylesheets/ff-theme-light.scss
+++ b/src/stylesheets/ff-theme-light.scss
@@ -1,6 +1,10 @@
 .ff-bg-light {
-    color: $ff-grey-800;
     background-color: $ff-grey-50;
+}
+
+.ff-theme-light {
+
+    color: $ff-grey-800;
 
     /* Core */
 


### PR DESCRIPTION
## Description

- Separates "theme" out of "bg". Clashing occurred as whilst we had dark theming in /flowforge, we didn't always utilise the `ff-bg-dark` theme, because it was opinionated on the background colour too, which in some cases 9e.g. sign up box) differed by a level of grey.
- This PR adds a new `ff-theme-<theme>` class set which will make it easier to inherit the dark themed classes on a component-by-component basis, _without_ affecting the `background-color`.
- In re-architecting this, also noticed a fair few components (`data-table`, `dropdown`, `notification` and the initially flagged `checkbox`/`radio-group` pair) that needed theming defined in dark mode. Whilst we hadn't utilised these components in a dark mode _yet_, they should still be well defined. These can sanity checked from within the `components` documentation where it's possible to switch to dark mode in the top-right.
- Includes a version bump to `v0.7.0`

## Related Issue(s)

Issue first raised here: https://github.com/flowforge/flowforge/issues/2419 but scale of the issue realised to be much bigger, and so this PR addresses the wider "Theming" architecture of forge-ui-components.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Documentation has been updated

