### PR TITLE
Import FFSpinner relatively and register with vue

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -33,6 +33,7 @@ import FFTab from './components/tabs/Tab.vue'
 import FFCheck from './components/Check.vue'
 import FFListItem from './components/ListItem.vue'
 import FFMarkdownViewer from './components/Markdown.vue'
+import FFSpinner from './components/Spinner.vue'
 
 export default {
     FFButton,
@@ -42,6 +43,7 @@ export default {
     FFListItem,
     FFCheck,
     FFMarkdownViewer,
+    FFSpinner,
     // Data Table
     FFDataTable,
     FFDataTableRow,

--- a/src/components/form/ToggleSwitch.vue
+++ b/src/components/form/ToggleSwitch.vue
@@ -4,20 +4,15 @@
         <div class="ff-toggle-switch-slider" @click="toggle">
             <div class="ff-toggle-switch-button">
                 <slot v-if="!loading"></slot>
-                <FFSpinner v-else />
+                <ff-spinner v-else />
             </div>
         </div>
     </label>
 </template>
 
 <script>
-import FFSpinner from '@/components/Spinner.vue'
-
 export default {
     name: 'ff-toggle-switch',
-    components: {
-        FFSpinner
-    },
     props: {
         disabled: {
             default: false,


### PR DESCRIPTION
## Description

Previously the spinner (from #150) was being imported as if it was an external dependency, which meant rollup was not including it in the bundle at build time:

> (!) Unresolved dependencies
https://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency
@/components/Spinner.vue (imported by "src/components/form/ToggleSwitch.vue?vue&type=script&lang.js")

## Related Issue(s)

Fixes #152

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

