### PR TITLE
ff-tabs now property driven, works better for async definitions

### DIFF
--- a/docs/DesignLanguage.vue
+++ b/docs/DesignLanguage.vue
@@ -675,21 +675,18 @@
                 <div class="examples">
                     <div class="example">
                         <h5>Example 1: Horizontal Tabs</h5>
-                        <ff-tabs orientation="horizontal">
-                            <ff-tab label="Option 1" to="" />
-                            <ff-tab label="Option 2" to="" />
-                            <ff-tab label="Option 3" to="" />
-                        </ff-tabs>
+                        <ff-tabs orientation="horizontal" :tabs="[{ label: 'Option 1' }, { label: 'Option 2' }, { label: 'Option 3' }]"></ff-tabs>
                         <code>{{ cGroups['tabs'].components[0].examples[0].code }}</code>
                     </div>
                     <div class="example">
                         <h5>Example 2: Vertical Tabs</h5>
-                        <ff-tabs orientation="vertical">
-                            <ff-tab label="Option 1" to="" />
-                            <ff-tab label="Option 2" to="" />
-                            <ff-tab label="Option 3" to="" />
-                        </ff-tabs>
+                        <ff-tabs orientation="vertical" :tabs="[{ label: 'Option 1' }, { label: 'Option 2' }, { label: 'Option 3' }]"></ff-tabs>
                         <code>{{ cGroups['tabs'].components[0].examples[1].code }}</code>
+                    </div>
+                    <div class="example">
+                        <h5>Example 3: Async</h5>
+                        <ff-tabs ref="asyncTabs" orientation="vertical" :tabs="tabs" />
+                        <code>{{ cGroups['tabs'].components[0].examples[2].code }}</code>
                     </div>
                 </div>
             </div>
@@ -810,6 +807,7 @@ export default {
                 tiles1: null,
                 tiles3: 3
             },
+            tabs: null,
             loading: {
                 switch3: false
             },
@@ -1015,6 +1013,7 @@ export default {
     async mounted () {
         await this.$nextTick()
         this.toSection(window.location.hash.replace('#', ''))
+        this.addAsyncTabs()
     },
     methods: {
         toSection (ref) {
@@ -1052,6 +1051,12 @@ export default {
                 this.models.switch3 = !this.models.switch3
                 this.loading.switch3 = false
             }, 2000)
+        },
+        addAsyncTabs () {
+            this.tabs = [
+                { label: 'My Label' },
+                { label: 'My Label 2' }
+            ]
         }
     }
 }

--- a/docs/data/tabs.docs.json
+++ b/docs/data/tabs.docs.json
@@ -5,9 +5,11 @@
     "components": [{
         "name": "ff-tabs",
         "examples": [{
-            "code": "<ff-tabs orientation=\"horizontal\">\n\t<ff-tab label=\"Option 1\" to=\"\" />\n\t<ff-tab label=\"Option 2\" to=\"\" />\n\t<ff-tab label=\"Option 3\" to=\"\" />\n</ff-tabs>"
+            "code": "<ff-tabs :tabs=\"[{ label: 'Option 1' }, { label: 'Option 2' }, { label: 'Option 3' }]\"></ff-tabs>"
         }, {
-            "code": "<ff-tabs orientation=\"vertical\">\n\t<ff-tab label=\"Option 1\" to=\"\" />\n\t<ff-tab label=\"Option 2\" to=\"\" />\n\t<ff-tab label=\"Option 3\" to=\"\" />\n</ff-tabs>"
+            "code": "<ff-tabs orientation=\"vertical\" :tabs=\"[{ label: 'Option 1' }, { label: 'Option 2' }, { label: 'Option 3' }]\"></ff-tabs>"
+        }, {
+            "code": "<ff-tabs orientation=\"vertical\" :tabs=\"tabs\"></ff-tabs>"
         }],
         "props": [{
             "key": "orientation",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowforge/forge-ui-components",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "",
     "author": {
         "name": "FlowForge Inc."

--- a/src/components/tabs/Tab.vue
+++ b/src/components/tabs/Tab.vue
@@ -12,7 +12,7 @@ export default {
         }
     },
     render: () => {
-        return null
+        return 'tabs'
     }
 }
 </script>

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -1,15 +1,12 @@
 <template>
     <div ref="ff-tabs">
         <ul class="ff-tabs" :class="'ff-tabs--' + orientation">
-            <li v-for="(tab, $index) in tabs" :key="tab.label" class="ff-tab-option transition-fade--color"
+            <li v-for="(tab, $index) in scopedTabs" :key="tab.label" class="ff-tab-option transition-fade--color"
                 :class="{'ff-tab-option--active': tab.isActive}" @click="selectTab($index)"
             >
                 {{ tab.label }}
             </li>
         </ul>
-        <div class="ff-tabs-content">
-            <slot></slot>
-        </div>
     </div>
 </template>
 
@@ -20,21 +17,29 @@ export default {
         orientation: {
             default: '',
             type: String
+        },
+        tabs: {
+            default: () => [],
+            type: Array
         }
     },
     emits: ['tab-selected'],
     data () {
         return {
-            tabs: [],
-            active: -1
+            selectedIndex: -1,
+            scopedTabs: []
         }
     },
-    created () {
-        this.tabs = this.$slots.default().map((vnode) => {
-            return vnode.props
-        })
+    watch: {
+        tabs: function () {
+            this.scopedTabs = this.tabs
+            console.log('tabs changed')
+            const index = this.selectedIndex < 0 ? 0 : this.selectedIndex
+            this.selectTab(index)
+        }
     },
     mounted () {
+        this.scopedTabs = this.tabs
         this.selectTab(0)
     },
     methods: {
@@ -42,7 +47,7 @@ export default {
             this.selectedIndex = i
 
             // loop over all the tabs
-            this.tabs.forEach((tab, index) => {
+            this.scopedTabs?.forEach((tab, index) => {
                 tab.isActive = (index === i)
                 if (tab.isActive) {
                     this.$emit('tab-selected', tab)


### PR DESCRIPTION
## Description

- Switched `ff-tabs` to be property/array driven, rather than `slot`
- It was cleaner to read, but functionally a nightmare to maintain when async changes were presented to the slot.
- Added a 3rd example which uses async defined tabs
- Version bump to 0.7.1

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Documentation has been updated

